### PR TITLE
set dev_id when creating bluez adapter from device info

### DIFF
--- a/src/bluez/adapter/mod.rs
+++ b/src/bluez/adapter/mod.rs
@@ -476,7 +476,7 @@ impl Adapter {
         info!("DevInfo: {:?}", di);
         Adapter {
             name: String::from(unsafe { CStr::from_ptr(di.name.as_ptr()).to_str().unwrap() }),
-            dev_id: 0,
+            dev_id: di.dev_id,
             addr: di.bdaddr,
             typ: AdapterType::parse((di.type_ & 0x30) >> 4),
             states: AdapterState::parse(di.flags),


### PR DESCRIPTION
PS: I noticed that my previous PR was set to the `dev` branch and not `master`, not sure if that was correct, I've put this one against `dev` too but things might need to be merged to master