### PR TITLE
Derive serde Serialize and Deserialize…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ failure_derive = "0.1.1"
 backtrace = "0.3.5"
 async-std = { version = "1.4.0", features = ["unstable"] }
 uuid = "0.8.1"
+serde = { version = "1.0", features = ["derive"] }
 
 [dependencies.nom]
 version = "^4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ failure_derive = "0.1.1"
 backtrace = "0.3.5"
 async-std = { version = "1.4.0", features = ["unstable"] }
 uuid = "0.8.1"
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0", features = ["derive"], default-features = false, optional = true }
 
 [dependencies.nom]
 version = "^4.0"

--- a/README.md
+++ b/README.md
@@ -164,6 +164,17 @@ Beyond that, some of our other goals are:
 | Write Descriptor (Sync) ||||
 | Write Descriptor (Async) ||||
 
+## Library Features
+
+#### Serialization/Deserialization
+
+To enable implementation of serde's `Serialize` and `Deserialize` across some common types in the `api` module, use the `serde` feature.
+
+```toml
+[dependencies]
+btleplug = { version = "0.4", features = ["serde"] }
+```
+
 ## Old rumble README Content
 
 ### Rumble

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -15,13 +15,15 @@ use std::{
     fmt::{self, Display, Formatter, Debug},
     collections::BTreeSet,
 };
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use crate::{
     Result,
     api::UUID::{B16, B128}
 };
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub enum AddressType {
     Random,
     Public,
@@ -49,6 +51,7 @@ impl AddressType {
 }
 
 /// Stores the 6 byte address used to identify Bluetooth devices.
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Copy, Clone, Hash, Eq, PartialEq, Default)]
 #[repr(C)]
 pub struct BDAddr {
@@ -89,7 +92,8 @@ pub type NotificationHandler = Box<dyn Fn(ValueNotification) + Send>;
 
 /// A Bluetooth UUID. These can either be 2 bytes or 16 bytes long. UUIDs uniquely identify various
 /// objects in the Bluetooth universe.
-#[derive(Ord, PartialOrd, Eq, PartialEq, Copy, Clone, Hash, Serialize, Deserialize)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Ord, PartialOrd, Eq, PartialEq, Copy, Clone, Hash)]
 pub enum UUID {
     B16(u16),
     B128([u8; 16]),
@@ -288,7 +292,8 @@ pub trait Peripheral: Send + Sync + Clone + Debug {
     fn on_notification(&self, handler: NotificationHandler);
 }
 
-#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Copy, Clone)]
 pub enum CentralEvent {
     DeviceDiscovered(BDAddr),
     DeviceLost(BDAddr),

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -15,12 +15,13 @@ use std::{
     fmt::{self, Display, Formatter, Debug},
     collections::BTreeSet,
 };
+use serde::{Deserialize, Serialize};
 use crate::{
     Result,
     api::UUID::{B16, B128}
 };
 
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub enum AddressType {
     Random,
     Public,
@@ -88,7 +89,7 @@ pub type NotificationHandler = Box<dyn Fn(ValueNotification) + Send>;
 
 /// A Bluetooth UUID. These can either be 2 bytes or 16 bytes long. UUIDs uniquely identify various
 /// objects in the Bluetooth universe.
-#[derive(Ord, PartialOrd, Eq, PartialEq, Copy, Clone, Hash)]
+#[derive(Ord, PartialOrd, Eq, PartialEq, Copy, Clone, Hash, Serialize, Deserialize)]
 pub enum UUID {
     B16(u16),
     B128([u8; 16]),
@@ -287,7 +288,7 @@ pub trait Peripheral: Send + Sync + Clone + Debug {
     fn on_notification(&self, handler: NotificationHandler);
 }
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
 pub enum CentralEvent {
     DeviceDiscovered(BDAddr),
     DeviceLost(BDAddr),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,6 +129,7 @@ extern crate failure;
 #[macro_use]
 extern crate failure_derive;
 
+use serde::{Deserialize, Serialize};
 use std::result;
 use std::time::Duration;
 
@@ -140,7 +141,7 @@ pub mod winrtble;
 pub mod corebluetooth;
 pub mod api;
 
-#[derive(Debug, Fail, Clone)]
+#[derive(Debug, Fail, Clone, Serialize, Deserialize)]
 pub enum Error {
     #[fail(display = "Permission denied")]
     PermissionDenied,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,7 +129,6 @@ extern crate failure;
 #[macro_use]
 extern crate failure_derive;
 
-use serde::{Deserialize, Serialize};
 use std::result;
 use std::time::Duration;
 
@@ -141,7 +140,7 @@ pub mod winrtble;
 pub mod corebluetooth;
 pub mod api;
 
-#[derive(Debug, Fail, Clone, Serialize, Deserialize)]
+#[derive(Debug, Fail, Clone)]
 pub enum Error {
     #[fail(display = "Permission denied")]
     PermissionDenied,


### PR DESCRIPTION
… for all public non-stateful structs and enums.  Solves #27.

Notably this isn't _all_ types, but this seemed to be a good balance.  Generally this cross-platform, public structs and enums that implement Copy.  It didn't seem so useful to allow serialization of things that are stateful, and the only other public types are within bluez and seem quite internal (maybe should be non-public or crate scoped).

There is some hit to compile times, it's 10% more for debug, and almost 25% more for release.  Not sure that should prevent this, but something worth considering.