### PR TITLE
For linux, default the scan to active, as this is what's in the docs.

### DIFF
--- a/src/bluez/adapter/mod.rs
+++ b/src/bluez/adapter/mod.rs
@@ -215,7 +215,7 @@ impl ConnectedAdapter {
         let connected = ConnectedAdapter {
             adapter: adapter.clone(),
             adapter_fd,
-            active: Arc::new(AtomicBool::new(false)),
+            active: Arc::new(AtomicBool::new(true)),
             filter_duplicates: Arc::new(AtomicBool::new(false)),
             should_stop,
             scan_enabled: Arc::new(AtomicBool::new(false)),


### PR DESCRIPTION
Had a strange issue where one of my devices never advertised its local name (but it did with noble for nodejs).  Appears that it only does so if the scan is active!

Documentation for the Central trait:
> Control whether to use active or passive scan mode to find BLE devices....Defaults to use active mode.

There's no control on this for Mac or Windows (the active fn is a noop), so no updates required for other platforms.