### PR TITLE
Don't block the thread that's reading from the socket…

### DIFF
--- a/src/bluez/adapter/mod.rs
+++ b/src/bluez/adapter/mod.rs
@@ -301,10 +301,12 @@ impl ConnectedAdapter {
     fn emit(&self, event: CentralEvent) {
         debug!("emitted {:?}", event);
         let handlers = self.event_handlers.clone();
-        let vec = handlers.lock().unwrap();
-        for handler in (*vec).iter() {
-            handler(event.clone());
-        }
+        thread::spawn(move || {
+            let vec = handlers.lock().unwrap();
+            for handler in (*vec).iter() {
+                handler(event.clone());
+            }
+        });
     }
 
     fn handle(&self, message: hci::Message) {


### PR DESCRIPTION
… with the user's callbacks on events.  Solves #25.

I'm not sure that this a _great_ solve.  @qdot, this sort of gets to your point of maybe registering sets of callbacks just isn't the right approach as a whole for rust.  If this were a stream, you wouldn't really face this issue in the first place.

This isn't strictly necessary, as the user can basically do this exact same thing around their own handlers--it's just not obvious when one might want to do so.