### PR TITLE
Updated windows BLE Manager + examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 /target/
 **/*.rs.bk
 Cargo.lock
+**/.vscode*
+/workspace.xml
+**/*.code-workspace

--- a/examples/discover_adapters_peripherals.rs
+++ b/examples/discover_adapters_peripherals.rs
@@ -24,8 +24,8 @@ fn connect_to(adapter: &Adapter) -> ConnectedAdapter {
 }
 #[cfg(target_os = "linux")]
 fn print_adapter_info(adapter: &ConnectedAdapter) {
-    println!("connected adapter {:?} is UP: {:?}", adapter.name, adapter.is_up());
-    println!("adapter states : {:?}", adapter.states);
+    println!("connected adapter {:?} is UP: {:?}", adapter.adapter.name, adapter.adapter.is_up());
+    println!("adapter states : {:?}", adapter.adapter.states);
 }
 
 #[cfg(target_os = "windows")]
@@ -51,16 +51,22 @@ fn main() {
     } else {
         for adapter in adapter_list.iter() {
             println!("connecting to BLE adapter: ...");
-            let connected_adapter = connect_to(&adapter);
+
+            let connected_adapter = if cfg!(windows) {
+                connect_to(&adapter)
+            } else {
+                connect_to(&adapter)
+            };
+            // let connected_adapter = connect_to(&adapter);
             print_adapter_info(&connected_adapter);
-            adapter.start_scan().expect("Can't scan BLE adapter for connected devices...");
+            connected_adapter.start_scan().expect("Can't scan BLE adapter for connected devices...");
             thread::sleep(Duration::from_secs(2));
-            if adapter.peripherals().is_empty() {
+            if connected_adapter.peripherals().is_empty() {
                 eprintln!("->>> BLE peripheral devices were not found, sorry. Exiting...");
             } else {
                  // all peripheral devices in range
                 // for peripheral in connected_adapter.peripherals().iter() {
-                for peripheral in adapter.peripherals().iter() {
+                for peripheral in connected_adapter.peripherals().iter() {
                     println!("peripheral : {:?} is connected: {:?}", peripheral.properties().local_name, peripheral.is_connected());
                     if peripheral.properties().local_name.is_some() && !peripheral.is_connected() {
                         println!("start connect to peripheral : {:?}...", peripheral.properties().local_name);

--- a/examples/discover_adapters_peripherals.rs
+++ b/examples/discover_adapters_peripherals.rs
@@ -50,6 +50,8 @@ fn main() {
                                     println!("{:?}", char_item);
                                 }
                             }
+                            println!("disconnecting from peripheral : {:?}...", peripheral.properties().local_name);
+                            peripheral.disconnect().expect("Error on disconnecting from BLE peripheral ");
                         }
                     } else {
                         //sometimes peripheral is not discovered completely

--- a/examples/discover_adapters_peripherals.rs
+++ b/examples/discover_adapters_peripherals.rs
@@ -1,0 +1,62 @@
+#[allow(unused_imports)]
+#[allow(dead_code)]
+
+use std::thread;
+use std::time::Duration;
+use rand::{Rng, thread_rng};
+#[cfg(target_os = "linux")]
+use btleplug::bluez::{adapter::ConnectedAdapter, manager::Manager};
+#[cfg(target_os = "windows")]
+use btleplug::winrtble::{adapter::Adapter, manager::Manager};
+#[cfg(target_os = "macos")]
+use btleplug::corebluetooth::{adapter::Adapter, manager::Manager};
+use btleplug::api::{UUID, Central, Peripheral, Characteristic};
+
+/**
+If you are getting run time error like that :
+ thread 'main' panicked at 'Can't scan BLE adapter for connected devices...: PermissionDenied', src/libcore/result.rs:1188:5
+ you can try to run app with > sudo ./discover_adapters_peripherals
+ on linux
+**/
+fn main() {
+    let manager = Manager::new().unwrap();
+    let adapter_list = manager.adapters().unwrap();
+    if adapter_list.len() <= 0 {
+        eprint!("Bluetooth adapter(s) were NOT found, sorry...\n");
+    } else {
+        for adapter in adapter_list.iter() {
+            println!("connecting to BLE adapter: {:?}...", adapter.name);
+            let connected_adapter: ConnectedAdapter = adapter.connect().expect("Error connecting to BLE Adapter....");
+            println!("connected adapter {:?} is UP: {:?}", connected_adapter.adapter.name, connected_adapter.adapter.is_up());
+            println!("adapter states : {:?}", connected_adapter.adapter.states);
+            thread::sleep(Duration::from_secs(2));
+            connected_adapter.start_scan().expect("Can't scan BLE adapter for connected devices...");
+            thread::sleep(Duration::from_secs(2));
+            if connected_adapter.peripherals().is_empty() {
+                eprintln!("->>> BLE peripheral devices were not found, sorry. Exiting...");
+            } else {
+                 // all peripheral devices in range
+                for peripheral in connected_adapter.peripherals().iter() {
+                    println!("peripheral : {:?} is connected: {:?}", peripheral.properties().local_name, peripheral.is_connected());
+                    if peripheral.properties().local_name.is_some() && !peripheral.is_connected() {
+                        println!("start connect to peripheral : {:?}...", peripheral.properties().local_name);
+                        peripheral.connect().expect("Can't connect to peripheral...");
+                        println!("now connected (\'{:?}\') to peripheral : {:?}...", peripheral.is_connected(), peripheral.properties().local_name);
+                        let chars = peripheral.discover_characteristics();
+                        if peripheral.is_connected() {
+                            println!("Discover peripheral : \'{:?}\' characteristics...", peripheral.properties().local_name);
+                            for chars_vector in chars.into_iter() {
+                                for char_item in chars_vector.iter() {
+                                    println!("{:?}", char_item);
+                                }
+                            }
+                        }
+                    } else {
+                        //sometimes peripheral is not discovered completely
+                        eprintln!("SKIP connect to UNKNOWN peripheral : {:?}", peripheral);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/examples/discover_adapters_peripherals.rs
+++ b/examples/discover_adapters_peripherals.rs
@@ -56,7 +56,6 @@ fn main() {
             adapter.start_scan().expect("Can't scan BLE adapter for connected devices...");
             thread::sleep(Duration::from_secs(2));
             if adapter.peripherals().is_empty() {
-            // if connected_adapter.peripherals().is_empty() {
                 eprintln!("->>> BLE peripheral devices were not found, sorry. Exiting...");
             } else {
                  // all peripheral devices in range

--- a/examples/discover_adapters_peripherals.rs
+++ b/examples/discover_adapters_peripherals.rs
@@ -65,7 +65,6 @@ fn main() {
                 eprintln!("->>> BLE peripheral devices were not found, sorry. Exiting...");
             } else {
                  // all peripheral devices in range
-                // for peripheral in connected_adapter.peripherals().iter() {
                 for peripheral in connected_adapter.peripherals().iter() {
                     println!("peripheral : {:?} is connected: {:?}", peripheral.properties().local_name, peripheral.is_connected());
                     if peripheral.properties().local_name.is_some() && !peripheral.is_connected() {

--- a/examples/lights.rs
+++ b/examples/lights.rs
@@ -13,7 +13,7 @@ use btleplug::corebluetooth::{adapter::Adapter, manager::Manager};
 use btleplug::api::{UUID, Central, Peripheral};
 
 // adapter retreival works differently depending on your platform right now.
-// API needs to be aligned.v
+// API needs to be aligned.
 
 // #[cfg(any(target_os = "windows", target_os = "macos"))]
 #[cfg(target_os = "windows")]
@@ -50,7 +50,7 @@ pub fn main() {
             .any(|name| name.contains("LEDBlue"))).unwrap();
 
     // connect to the device
-    // light.connect().unwrap();
+    light.connect().unwrap();
 
     // discover characteristics
     light.discover_characteristics().unwrap();

--- a/examples/lights.rs
+++ b/examples/lights.rs
@@ -13,11 +13,14 @@ use btleplug::corebluetooth::{adapter::Adapter, manager::Manager};
 use btleplug::api::{UUID, Central, Peripheral};
 
 // adapter retreival works differently depending on your platform right now.
-// API needs to be aligned.
+// API needs to be aligned.v
 
-#[cfg(any(target_os = "windows", target_os = "macos"))]
+// #[cfg(any(target_os = "windows", target_os = "macos"))]
+#[cfg(target_os = "windows")]
 fn get_central(manager: &Manager) -> Adapter {
-    manager.adapters().unwrap()
+    let adapters = manager.adapters().unwrap();
+    let adapter = adapters.into_iter().nth(0).unwrap();
+    adapter
 }
 
 #[cfg(target_os = "linux")]
@@ -47,7 +50,7 @@ pub fn main() {
             .any(|name| name.contains("LEDBlue"))).unwrap();
 
     // connect to the device
-    light.connect().unwrap();
+    // light.connect().unwrap();
 
     // discover characteristics
     light.discover_characteristics().unwrap();

--- a/src/bluez/adapter/mod.rs
+++ b/src/bluez/adapter/mod.rs
@@ -170,7 +170,7 @@ impl AdapterState {
 
         let mut set = HashSet::new();
         for (i, f) in states.iter().enumerate() {
-            if flags & (1 << (i & 31)) != 0 {
+            if flags & (1 << (i & 31)) as u32 != 0 {
                 set.insert(f.clone());
             }
         }
@@ -233,15 +233,15 @@ impl ConnectedAdapter {
 
     fn set_socket_filter(&self) -> Result<()> {
         let mut filter = BytesMut::with_capacity(14);
-        let type_mask = (1 << HCI_COMMAND_PKT) | (1 << HCI_EVENT_PKT) | (1 << HCI_ACLDATA_PKT);
+        let type_mask = (1 << HCI_COMMAND_PKT) | (1 << HCI_EVENT_PKT) as u8 | (1 << HCI_ACLDATA_PKT) as u8;
         let event_mask1 = (1 << EVT_DISCONN_COMPLETE) | (1 << EVT_ENCRYPT_CHANGE) |
             (1 << EVT_CMD_COMPLETE) | (1 << EVT_CMD_STATUS);
         let event_mask2 = 1 << (EVT_LE_META_EVENT - 32);
         let opcode = 0;
 
-        filter.put_u32_le(type_mask);
-        filter.put_u32_le(event_mask1);
-        filter.put_u32_le(event_mask2);
+        filter.put_u32_le(type_mask as u32);
+        filter.put_u32_le(event_mask1 as u32);
+        filter.put_u32_le(event_mask2 as u32);
         filter.put_u16_le(opcode);
 
         handle_error(unsafe {

--- a/src/winrtble/manager.rs
+++ b/src/winrtble/manager.rs
@@ -16,6 +16,7 @@ use winrt::{
     windows::devices::radios::{Radio, RadioKind},
 };
 use super::adapter::Adapter;
+#[allow(unused_imports)]
 use crate::{Result, Error};
 
 pub struct Manager {
@@ -26,18 +27,20 @@ impl Manager {
         Ok(Self {})
     }
 
-    pub fn adapters(&self) -> Result<Adapter> {
+    pub fn adapters(&self) -> Result<Vec<Adapter>> {
+        let mut result: Vec<Adapter> = vec![];
         let radios = Radio::get_radios_async().unwrap().blocking_get().unwrap().unwrap();
 
         for radio in &radios {
             if let Some(radio) = radio {
                 if let Ok(kind) = radio.get_kind() {
                     if kind == RadioKind::Bluetooth {
-                        return Ok(Adapter::new());
+                        // try create BLE adapter
+                        result.push(Adapter::new());
                     }
                 }
             }
         }
-        Err(Error::NotSupported("no bluetooth adapter found".into()))
+        return Ok(result); 
     }
 }


### PR DESCRIPTION
- BL Manager for windows now returns list of adapters to be consistent with other version
- updated /examples for new signature, updated discover_adapters_peripherals.rs to be compiled in Linux + Windows OS
- minor warning fixes 

I can't really check windows code in run-time because I have only Windows 8 available, sorry