### PR TITLE
Correct comment regarding BlueZ sockets

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,8 +13,8 @@
 
 
 //! BtlePlug is a Bluetooth Low Energy (BLE) central module library for Rust. It
-//! currently supports Windows 10, macOS (and possibly iOS), Linux (using
-//! sockets instead of Bluez). Android support is coming in a future update.
+//! currently supports Windows 10, macOS (and possibly iOS), Linux (using BlueZ
+//! sockets instead of D-Bus). Android support is coming in a future update.
 //!
 //! ## Usage
 //!


### PR DESCRIPTION
Small fix for comment that confused me for a second. The updated text is consistent with the rumble README quoted in this repo's README:

https://github.com/deviceplug/btleplug/blob/984e6cf363176927c008d8a5d26b01edac4517cf/README.md#rumble