### PR TITLE
Correctly get peripheral local_name on macOS 10.15

### DIFF
--- a/src/corebluetooth/adapter.rs
+++ b/src/corebluetooth/adapter.rs
@@ -66,6 +66,12 @@ impl Adapter {
                             p.insert(id, Peripheral::new(uuid, name, handler_clone.clone(), event_receiver, adapter_sender_clone.clone()));
                             emit(CentralEvent::DeviceDiscovered(id));
                         },
+                        CoreBluetoothEvent::DeviceUpdated(uuid, name) => {
+                            let id = uuid_to_bdaddr(&uuid.to_string());
+                            let mut p = peripherals_clone.lock().unwrap();
+                            p.get_mut(&id).unwrap().properties.local_name = Some(name);
+                            emit(CentralEvent::DeviceUpdated(id));
+                        },
                         _ => {}
                     }
                 }

--- a/src/corebluetooth/internal.rs
+++ b/src/corebluetooth/internal.rs
@@ -214,6 +214,7 @@ pub enum CoreBluetoothEvent {
     AdapterError,
     // name, identifier, event receiver, message sender
     DeviceDiscovered(Uuid, String, async_std::sync::Receiver<CBPeripheralEvent>),
+    DeviceUpdated(Uuid, String),
     // identifier
     DeviceLost(Uuid),
 }
@@ -254,7 +255,11 @@ impl CoreBluetoothInternal {
         let uuid_nsstring = ns::uuid_uuidstring(cb::peer_identifier(*peripheral));
         let uuid = Uuid::from_str(&NSStringUtils::string_to_string(uuid_nsstring)).unwrap();
         let name = NSStringUtils::string_to_string(cb::peripheral_name(*peripheral));
-        if !self.peripherals.contains_key(&uuid) {
+        if self.peripherals.contains_key(&uuid) {
+            if name != String::from("nil") {
+                self.dispatch_event(CoreBluetoothEvent::DeviceUpdated(uuid, name));
+            }
+        } else {
             // if name.contains("LVS") {
             //     self.connect_peripheral(*peripheral);
             // }

--- a/src/corebluetooth/peripheral.rs
+++ b/src/corebluetooth/peripheral.rs
@@ -41,7 +41,7 @@ pub struct Peripheral {
     adapter_handlers: Arc<Mutex<Vec<EventHandler>>>,
     uuid: Uuid,
     characteristics: Arc<Mutex<BTreeSet<Characteristic>>>,
-    properties: PeripheralProperties,
+    pub(crate) properties: PeripheralProperties,
     event_receiver: Receiver<CBPeripheralEvent>,
     message_sender: Sender<CoreBluetoothMessage>,
     // We're not actually holding a peripheral object here, that's held out in


### PR DESCRIPTION
MacOS 10.15 (10.14?) somehow changed the process of peripheral discovering, we may not have the name when the first time a device is discovered, and the name comes with following `centralManager:didDiscover...` events.