### PR TITLE
Use const rather a mut object to write

### DIFF
--- a/src/bluez/adapter/mod.rs
+++ b/src/bluez/adapter/mod.rs
@@ -383,11 +383,11 @@ impl ConnectedAdapter {
         }
     }
 
-    fn write(&self, message: &mut [u8]) -> Result<()> {
+    fn write(&self, message: & [u8]) -> Result<()> {
         debug!("writing({}) {:?}", self.adapter_fd, message);
-        let ptr = message.as_mut_ptr();
+        let ptr = message.as_ptr();
         handle_error(unsafe {
-            libc::write(self.adapter_fd, ptr as *mut _ as *mut libc::c_void, message.len()) as i32
+            libc::write(self.adapter_fd, ptr as *const libc::c_void, message.len()) as i32
         })?;
         Ok(())
     }


### PR DESCRIPTION
I looked into the code in order trying to understand how to use Bluez. 
This part stuck as it looked weird. Why should we use a mutable object for libc::write ?
Monkey patched it to use a const object 