### PR TITLE
Remember data from previous advertisements

### DIFF
--- a/src/api/adapter_manager.rs
+++ b/src/api/adapter_manager.rs
@@ -75,14 +75,21 @@ impl<PeripheralType> AdapterManager<PeripheralType> where PeripheralType: Periph
   }
 
   pub fn add_peripheral(&self, addr: BDAddr, peripheral: PeripheralType) {
-      if self.peripherals.contains_key(&addr) {
-          panic!("Adding a peripheral that's already in the map.");
-      }
+      assert!(!self.peripherals.contains_key(&addr), "Adding a peripheral that's already in the map.");
+      assert_eq!(peripheral.address(), addr, "Device has unexpected address."); // TODO remove addr argument
       self.peripherals.insert(addr, peripheral);
   }
 
-  pub fn update_peripheral(&self, _addr: BDAddr, _peripheral: PeripheralType) {
-
+  pub fn update_peripheral(&self, addr: BDAddr, peripheral: PeripheralType) {
+      // FIXME: this function is too easy to use incorrectly.
+      // when you get a peripheral from self.peripheral() you can forget to call update_peripheral easily.
+      // and when you do, there is no guarantee that it hasn't been updated by someone else, causing changes
+      // to be lost.
+      // one way to fix it is to make this function work more similarly to (and/or use) DashMap::alter.
+      // also, firing of events (self.emit) should probably be done here, instead of in peripheral impls.
+      assert!(self.peripherals.contains_key(&addr), "Updating a peripheral that's not in the map.");
+      assert_eq!(peripheral.address(), addr, "Device has unexpected address."); // TODO remove addr argument
+      self.peripherals.insert(addr, peripheral);
   }
 
   pub fn peripherals(&self) -> Vec<PeripheralType> {

--- a/src/bluez/protocol/hci.rs
+++ b/src/bluez/protocol/hci.rs
@@ -563,7 +563,11 @@ fn le_advertising_data(i: &[u8]) -> IResult<&[u8], Vec<LEAdvertisingData>> {
 named!(le_advertising_info<&[u8], LEAdvertisingInfo>,
     do_parse!(
        // TODO: support counts other than 1
-       _count: le_u8 >>
+       // note that if count > 1, *every individual field* is an array of that many items.
+       // we'd then have to piece that back together into separate events.
+       // but, hopefully this less-than-reasonable layout guarantees that no hardware actually uses count > 1.
+       // see https://stackoverflow.com/questions/26275679/ble-hci-le-advertising-report-event-data-format
+       _count: verify!(le_u8, |c| c == 1) >>
        evt_type: le_u8 >>
        bdaddr_type: le_u8 >>
        bdaddr: bd_addr >>

--- a/src/winrtble/adapter.rs
+++ b/src/winrtble/adapter.rs
@@ -49,7 +49,8 @@ impl Central<Peripheral> for Adapter {
         watcher.start(Box::new(move |args| {
             let bluetooth_address = args.get_bluetooth_address().unwrap();
             let address = utils::to_addr(bluetooth_address);
-            let peripheral = Peripheral::new(manager.clone(), address);
+            let peripheral = self.manager.peripheral(address)
+                .unwrap_or_else(|| Peripheral::new(manager.clone(), address));
             peripheral.update_properties(&args);
             if !manager.has_peripheral(&address) {
                 manager.add_peripheral(address, peripheral);


### PR DESCRIPTION
Right now, as soon as one piece of data comes in, all previous ones
are forgotten. This makes it impossible to match devices by name, if
more data is received after the advertisement containing the name.

This fixes the problem on linux and windows. I've made no changes to the
mac code, as I'm not sure it even implements this.

This is lightly tested at the moment. I ran unit tests, and the linux
changes are copied by hand from a more comprehensively modified local
version, on which they work (and fix the described problem).

Windows changes are trivial but have not been tested at all.

I added a number of comments to help others trying to work with the
code. Some may be subjective, in which case, change them as desired.