### PR TITLE
Improve error message for lights example.

### DIFF
--- a/examples/lights.rs
+++ b/examples/lights.rs
@@ -52,7 +52,7 @@ pub fn main() {
                 .iter()
                 .any(|name| name.contains("LEDBlue"))
         })
-        .unwrap();
+        .expect("No lights found");
 
     // connect to the device
     light.connect().unwrap();


### PR DESCRIPTION
This is a very minor thing.
The change just communicates the error better when running the `lights` example without any lights available (which I imagine will be most people).

Before:
```
thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', examples/lights.rs:55:10
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

After:
```
thread 'main' panicked at 'No lights found', examples/lights.rs:55:10
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```