### PR TITLE
feat: Add write with response and read on Core Bluetooth

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Beyond that, some of our other goals are:
 | GATT Server Disconnect Event |X|X|X|
 | Write to Characteristic (Sync) |X|X|X|
 | Write to Characteristic (Async) |||X|
-| Read from Characteristic (Sync) |X||X|
+| Read from Characteristic (Sync) |X|X|X|
 | Read from Characteristic (Async) |X|||
 | Subscribe to Characteristic (Sync) |X|X|X|
 | Subscribe to Characteristic (Async) ||||

--- a/src/corebluetooth/central_delegate.rs
+++ b/src/corebluetooth/central_delegate.rs
@@ -35,7 +35,7 @@ use super::{
 
 use uuid::Uuid;
 
-use libc::{c_void, c_char};
+use libc::{c_char, c_void};
 use std::ffi::CStr;
 
 pub enum CentralDelegateEvent {

--- a/src/corebluetooth/framework.rs
+++ b/src/corebluetooth/framework.rs
@@ -408,8 +408,7 @@ pub mod cb {
         write_type: usize,
     ) {
         unsafe {
-            let _: () =
-                msg_send![cbperipheral, writeValue:value forCharacteristic:characteristic type:write_type];
+            let _: () = msg_send![cbperipheral, writeValue:value forCharacteristic:characteristic type:write_type];
             // CBCharacteristicWriteWithResponse from CBPeripheral.h
         }
     }

--- a/src/corebluetooth/framework.rs
+++ b/src/corebluetooth/framework.rs
@@ -392,7 +392,7 @@ pub mod cb {
         }
     }
 
-    pub fn peripheral_readvalueforcharacteristic(
+    pub fn peripheral_readvalue_forcharacteristic(
         cbperipheral: *mut Object,
         characteristic: *mut Object, /* CBCharacteristic* */
     ) {
@@ -405,10 +405,11 @@ pub mod cb {
         cbperipheral: *mut Object,
         value: *mut Object,          /* NSData* */
         characteristic: *mut Object, /* CBCharacteristic* */
+        write_type: usize,
     ) {
         unsafe {
             let _: () =
-                msg_send![cbperipheral, writeValue:value forCharacteristic:characteristic type:0];
+                msg_send![cbperipheral, writeValue:value forCharacteristic:characteristic type:write_type];
             // CBCharacteristicWriteWithResponse from CBPeripheral.h
         }
     }

--- a/src/corebluetooth/internal.rs
+++ b/src/corebluetooth/internal.rs
@@ -351,7 +351,10 @@ impl CoreBluetoothInternal {
                 for byte in data.iter() {
                     data_clone.push(*byte);
                 }
-                state.lock().unwrap().set_reply(CoreBluetoothReply::ReadResult(data_clone));
+                state
+                    .lock()
+                    .unwrap()
+                    .set_reply(CoreBluetoothReply::ReadResult(data_clone));
                 task::block_on(async {
                     p.event_sender
                         .send(CBPeripheralEvent::Notification(characteristic_uuid, data))
@@ -361,11 +364,7 @@ impl CoreBluetoothInternal {
         }
     }
 
-    fn on_characteristic_written(
-        &mut self,
-        peripheral_uuid: Uuid,
-        characteristic_uuid: Uuid,
-    ) {
+    fn on_characteristic_written(&mut self, peripheral_uuid: Uuid, characteristic_uuid: Uuid) {
         if let Some(p) = self.peripherals.get_mut(&peripheral_uuid) {
             if let Some(c) = p.characteristics.get_mut(&characteristic_uuid) {
                 info!("Got written event!");
@@ -390,7 +389,7 @@ impl CoreBluetoothInternal {
         characteristic_uuid: Uuid,
         data: Vec<u8>,
         fut: CoreBluetoothReplyStateShared,
-        with_response: bool
+        with_response: bool,
     ) {
         if let Some(p) = self.peripherals.get_mut(&peripheral_uuid) {
             if let Some(c) = p.characteristics.get_mut(&characteristic_uuid) {
@@ -419,10 +418,7 @@ impl CoreBluetoothInternal {
         if let Some(p) = self.peripherals.get_mut(&peripheral_uuid) {
             if let Some(c) = p.characteristics.get_mut(&characteristic_uuid) {
                 info!("Reading value!");
-                cb::peripheral_readvalue_forcharacteristic(
-                    *p.peripheral,
-                    *c.characteristic,
-                );
+                cb::peripheral_readvalue_forcharacteristic(*p.peripheral, *c.characteristic);
                 c.read_future_state.push_front(fut);
             }
         }
@@ -523,7 +519,7 @@ impl CoreBluetoothInternal {
                     ) => self.on_characteristic_read(peripheral_id, characteristic_id, data),
                     CentralDelegateEvent::CharacteristicWritten(
                         peripheral_id,
-                        characteristic_id
+                        characteristic_id,
                     ) => self.on_characteristic_written(peripheral_id, characteristic_id),
                     _ => info!("Unknown type!"),
                 };
@@ -545,9 +541,12 @@ impl CoreBluetoothInternal {
                     CoreBluetoothMessage::WriteValue(peripheral_uuid, char_uuid, data, fut) => {
                         self.write_value(peripheral_uuid, char_uuid, data, fut, false)
                     }
-                    CoreBluetoothMessage::WriteValueWithResponse(peripheral_uuid, char_uuid, data, fut) => {
-                        self.write_value(peripheral_uuid, char_uuid, data, fut, true)
-                    }
+                    CoreBluetoothMessage::WriteValueWithResponse(
+                        peripheral_uuid,
+                        char_uuid,
+                        data,
+                        fut,
+                    ) => self.write_value(peripheral_uuid, char_uuid, data, fut, true),
                     CoreBluetoothMessage::Subscribe(peripheral_uuid, char_uuid, fut) => {
                         self.subscribe(peripheral_uuid, char_uuid, fut)
                     }

--- a/src/corebluetooth/peripheral.rs
+++ b/src/corebluetooth/peripheral.rs
@@ -280,10 +280,10 @@ impl ApiPeripheral for Peripheral {
                 ))
                 .await;
             match fut.await {
-                CoreBluetoothReply::Ok => {},
+                CoreBluetoothReply::Ok => {}
                 _ => {
                     panic!("Shouldn't get anything but read result!");
-                },
+                }
             }
         });
         Ok(result)
@@ -379,7 +379,7 @@ impl ApiPeripheral for Peripheral {
                 }
                 _ => {
                     panic!("Shouldn't get anything but read result!");
-                },
+                }
             }
         });
         Ok(result)


### PR DESCRIPTION
As the title says. Plus, for debugging purposes, I had to get the message from the error objects that get passed by Core Bluetooth on failure. I thought this would be a nice addition to the code, so we get more context than just `error`.

Please note: I am a total Rust n00b, so there may be a lot of stuff in this PR that is not idiomatic Rust. Please bare with me. I am super interested in fixing that, though, so any comments are welcome.

I've tried to keep the current code style.

Oh, and one last thing: It would totally make sense to split this PR into two - one for adding read support, another for adding write with response. However, the BLE device I am trying to get working (a smart radiator valve) requires both to be in place before I know it's working, so I am unable to do the split and tell if either works by itself.