### PR TITLE
Refactor BDAddr

### DIFF
--- a/src/api/bdaddr.rs
+++ b/src/api/bdaddr.rs
@@ -148,7 +148,7 @@ impl BDAddr {
     pub fn from_str_delim(s: &str) -> Result<Self, ParseBDAddrError> {
         let bytes = s
             .split(':')
-            .map(|part: &str| u8::from_str_radix(part, 16).map_err(ParseBDAddrError::InvalidDigit))
+            .map(|part: &str| u8::from_str_radix(part, 16))
             .collect::<Result<Vec<u8>, _>>()?;
 
         if bytes.len() == 6 {

--- a/src/api/bdaddr.rs
+++ b/src/api/bdaddr.rs
@@ -136,11 +136,13 @@ impl BDAddr {
     pub fn into_inner(self) -> [u8; 6] {
         self.address
     }
+
     /// Check if this address is a randomly generated.
     pub fn is_random_static(&self) -> bool {
         self.address[5] & 0b11 == 0b11
     }
-    /// Parses a Bluetooth address colons `:` as delimiters.
+
+    /// Parses a Bluetooth address with colons `:` as delimiters.
     ///
     /// All hex-digits `[0-9a-fA-F]` are allowed.
     pub fn from_str_delim(s: &str) -> Result<Self, ParseBDAddrError> {
@@ -157,6 +159,7 @@ impl BDAddr {
             Err(ParseBDAddrError::IncorrectByteCount)
         }
     }
+
     /// Parses a Bluetooth address without delimiters.
     ///
     /// All hex-digits `[0-9a-fA-F]` are allowed.
@@ -174,6 +177,7 @@ impl BDAddr {
         }
         Ok(Self { address })
     }
+
     /// Writes the address without delimiters.
     pub fn write_no_delim(&self, f: &mut impl fmt::Write) -> fmt::Result {
         for b in &self.address {
@@ -181,6 +185,7 @@ impl BDAddr {
         }
         Ok(())
     }
+
     /// Create a `String` with the address with no delimiters.
     ///
     /// For the more common presentation with colons use the `to_string()`

--- a/src/api/bdaddr.rs
+++ b/src/api/bdaddr.rs
@@ -1,0 +1,270 @@
+//! Implementation of Bluetooth's MAC address.
+
+use std::fmt;
+use std::str::FromStr;
+use thiserror::Error;
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+#[cfg(feature = "serde")]
+use serde_cr as serde;
+
+use crate::Error;
+
+/// Stores the 6 byte address used to identify Bluetooth devices.
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_cr")
+)]
+#[derive(Copy, Clone, Hash, Eq, PartialEq, Default)]
+#[repr(C)]
+pub struct BDAddr {
+    address: [u8; 6usize],
+}
+
+#[derive(Debug, Error, Clone, PartialEq)]
+pub enum ParseBDAddrError {
+    #[error("Bluetooth address has to be 6 bytes long")]
+    IncorrectByteCount,
+    #[error("All digits in a Bluetooth address must be hex-digits [0-9a-fA-F]")]
+    InvalidDigit,
+}
+
+impl fmt::Display for BDAddr {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        <Self as fmt::LowerHex>::fmt(self, f)
+    }
+}
+
+impl fmt::LowerHex for BDAddr {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let a = &self.address;
+        write!(
+            f,
+            "{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
+            a[0], a[1], a[2], a[3], a[4], a[5]
+        )
+    }
+}
+
+impl fmt::UpperHex for BDAddr {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let a = &self.address;
+        write!(
+            f,
+            "{:02X}:{:02X}:{:02X}:{:02X}:{:02X}:{:02X}",
+            a[0], a[1], a[2], a[3], a[4], a[5]
+        )
+    }
+}
+
+impl fmt::Debug for BDAddr {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        <Self as fmt::Display>::fmt(self, f)
+    }
+}
+
+impl AsRef<[u8]> for BDAddr {
+    fn as_ref(&self) -> &[u8] {
+        &self.address
+    }
+}
+
+impl From<[u8; 6]> for BDAddr {
+    /// Build an address from an array.
+    ///
+    /// `address[0]` will be the MSB and `address[5]` the LSB.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use btleplug::api::BDAddr;
+    /// let addr: BDAddr = [0x2a, 0xCC, 0x00, 0x34, 0xfa, 0x00].into();
+    /// assert_eq!("2a:cc:00:34:fa:00", addr.to_string());
+    /// ```
+    fn from(address: [u8; 6]) -> Self {
+        Self { address }
+    }
+}
+
+impl<'a> std::convert::TryFrom<&'a [u8]> for BDAddr {
+    type Error = ParseBDAddrError;
+
+    fn try_from(slice: &'a [u8]) -> Result<Self, Self::Error> {
+        if slice.len() < 6 {
+            Err(ParseBDAddrError::IncorrectByteCount)
+        } else {
+            let mut cpy = [0; 6];
+            cpy.copy_from_slice(&slice[..6]);
+            Ok(cpy.into())
+        }
+    }
+}
+
+impl From<u64> for BDAddr {
+    fn from(int: u64) -> Self {
+        let mut cpy = [0; 6];
+        let slice = int.to_be_bytes(); // Reverse order to have MSB on index 0
+        cpy.copy_from_slice(&slice[2..]);
+        cpy.into()
+    }
+}
+
+impl From<BDAddr> for u64 {
+    fn from(addr: BDAddr) -> Self {
+        let mut slice = [0; 8];
+        (&mut slice[2..]).copy_from_slice(&addr.into_inner());
+        u64::from_be_bytes(slice)
+    }
+}
+
+impl From<ParseBDAddrError> for Error {
+    fn from(e: ParseBDAddrError) -> Self {
+        Error::Other(format!("ParseBDAddrError: {}", e))
+    }
+}
+
+impl FromStr for BDAddr {
+    type Err = ParseBDAddrError;
+
+    /// Parses a Bluetooth address of the form `aa:bb:cc:dd:ee:ff` or of form
+    /// `aabbccddeeff`.
+    ///
+    /// All hex-digits `[0-9a-fA-F]` are allowed.
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.contains(':') {
+            Self::from_str_delim(s)
+        } else {
+            Self::from_str_no_delim(s)
+        }
+    }
+}
+
+impl BDAddr {
+    pub fn into_inner(self) -> [u8; 6] {
+        self.address
+    }
+    pub fn bytes(&self) -> &[u8; 6] {
+        &self.address
+    }
+    /// Check if this address is a randomly generated.
+    pub fn is_random_static(&self) -> bool {
+        self.address[5] & 0b11 == 0b11
+    }
+    /// Parses a Bluetooth address colons `:` as delimiters.
+    ///
+    /// All hex-digits `[0-9a-fA-F]` are allowed.
+    pub fn from_str_delim(s: &str) -> Result<Self, ParseBDAddrError> {
+        let bytes = s
+            .split(':')
+            .map(|part: &str| {
+                u8::from_str_radix(part, 16).map_err(|_| ParseBDAddrError::InvalidDigit)
+            })
+            .collect::<Result<Vec<u8>, _>>()?;
+
+        if bytes.len() == 6 {
+            let mut address = [0; 6];
+            address.copy_from_slice(bytes.as_slice());
+            Ok(BDAddr { address })
+        } else {
+            Err(ParseBDAddrError::IncorrectByteCount)
+        }
+    }
+    /// Parses a Bluetooth address without delimiters.
+    ///
+    /// All hex-digits `[0-9a-fA-F]` are allowed.
+    pub fn from_str_no_delim(s: &str) -> Result<Self, ParseBDAddrError> {
+        if s.len() != 12 {
+            return Err(ParseBDAddrError::IncorrectByteCount);
+        }
+        if s.bytes().any(|b| !b.is_ascii_hexdigit()) {
+            return Err(ParseBDAddrError::InvalidDigit);
+        }
+
+        let mut address = [0; 6];
+        for i in (0..12).step_by(2) {
+            let part = &s[i..i + 2];
+            address[i / 2] = u8::from_str_radix(part, 16).expect("Checked upfront");
+        }
+        Ok(Self { address })
+    }
+    /// Writes the address without delimiters.
+    pub fn write_flat(&self, f: &mut impl fmt::Write) -> fmt::Result {
+        for b in &self.address {
+            write!(f, "{:02x}", b)?;
+        }
+        Ok(())
+    }
+    /// Create a `String` with the address with no delimiters.
+    ///
+    /// For the more common presentation with colons use the `to_string()`
+    /// method.
+    pub fn to_string_flat(&self) -> String {
+        let mut s = String::with_capacity(12);
+        self.write_flat(&mut s)
+            .expect("A String-Writer never fails");
+        s
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A BDAddr with the same value as `HEX`.
+    const ADDR: BDAddr = BDAddr {
+        address: [0x1f, 0x2a, 0x00, 0xcc, 0x22, 0xf1],
+    };
+    /// A u64 with the same value as `ADDR`.
+    const HEX: u64 = 0x00_00_1f_2a_00_cc_22_f1;
+
+    #[test]
+    fn parse_addr() {
+        let bytes = [0x2a, 0x00, 0xaa, 0xbb, 0xcc, 0xdd];
+        let values = vec![
+            ("2a:00:aa:bb:cc:dd", Ok(BDAddr { address: bytes })),
+            ("2a00AabbCcdd", Ok(BDAddr { address: bytes })),
+            ("2A:00:00", Err(ParseBDAddrError::IncorrectByteCount)),
+            ("2A:00:AA:BB:CC:ZZ", Err(ParseBDAddrError::InvalidDigit)),
+            ("2A00aABbcCZz", Err(ParseBDAddrError::InvalidDigit)),
+        ];
+
+        for (input, expected) in values {
+            println!("testing: {}", input);
+            let result: Result<BDAddr, _> = input.parse();
+            assert_eq!(result, expected);
+
+            if let Ok(addr) = result {
+                assert_eq!(bytes, addr.into_inner());
+            }
+        }
+    }
+
+    #[test]
+    fn display_addr() {
+        assert_eq!(format!("{}", ADDR), "1f:2a:00:cc:22:f1");
+        assert_eq!(format!("{:?}", ADDR), "1f:2a:00:cc:22:f1");
+        assert_eq!(format!("{:x}", ADDR), "1f:2a:00:cc:22:f1");
+        assert_eq!(format!("{:X}", ADDR), "1F:2A:00:CC:22:F1");
+        assert_eq!(format!("{}", ADDR.to_string_flat()), "1f2a00cc22f1");
+    }
+
+    #[test]
+    fn u64_to_addr() {
+        let hex_addr: BDAddr = HEX.into();
+        assert_eq!(hex_addr, ADDR);
+
+        let hex_back: u64 = hex_addr.into();
+        assert_eq!(HEX, hex_back);
+    }
+
+    #[test]
+    fn addr_to_u64() {
+        let addr_as_hex: u64 = ADDR.into();
+        assert_eq!(HEX, addr_as_hex);
+
+        let addr_back: BDAddr = addr_as_hex.into();
+        assert_eq!(ADDR, addr_back);
+    }
+}

--- a/src/api/bdaddr.rs
+++ b/src/api/bdaddr.rs
@@ -1,5 +1,6 @@
 //! Implementation of Bluetooth's MAC address.
 
+use std::convert::{TryFrom, TryInto};
 use std::fmt::{self, Debug, Display, Formatter, LowerHex, UpperHex};
 use std::str::FromStr;
 
@@ -84,26 +85,24 @@ impl From<[u8; 6]> for BDAddr {
     }
 }
 
-impl<'a> std::convert::TryFrom<&'a [u8]> for BDAddr {
+impl<'a> TryFrom<&'a [u8]> for BDAddr {
     type Error = ParseBDAddrError;
 
     fn try_from(slice: &'a [u8]) -> Result<Self, Self::Error> {
-        if slice.len() < 6 {
-            Err(ParseBDAddrError::IncorrectByteCount)
-        } else {
-            let mut cpy = [0; 6];
-            cpy.copy_from_slice(&slice[..6]);
-            Ok(cpy.into())
-        }
+        Ok(Self {
+            address: slice
+                .try_into()
+                .map_err(|_| ParseBDAddrError::IncorrectByteCount)?,
+        })
     }
 }
 
 impl From<u64> for BDAddr {
     fn from(int: u64) -> Self {
-        let mut cpy = [0; 6];
         let slice = int.to_be_bytes(); // Reverse order to have MSB on index 0
-        cpy.copy_from_slice(&slice[2..]);
-        cpy.into()
+        Self {
+            address: slice[2..].try_into().unwrap(),
+        }
     }
 }
 

--- a/src/api/bdaddr.rs
+++ b/src/api/bdaddr.rs
@@ -76,8 +76,8 @@ impl From<[u8; 6]> for BDAddr {
     ///
     /// ```
     /// # use btleplug::api::BDAddr;
-    /// let addr: BDAddr = [0x2a, 0xCC, 0x00, 0x34, 0xfa, 0x00].into();
-    /// assert_eq!("2a:cc:00:34:fa:00", addr.to_string());
+    /// let addr: BDAddr = [0x2A, 0xCC, 0x00, 0x34, 0xFA, 0x00].into();
+    /// assert_eq!("2A:CC:00:34:FA:00", addr.to_string());
     /// ```
     fn from(address: [u8; 6]) -> Self {
         Self { address }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -239,7 +239,7 @@ impl BDAddr {
         if s.len() != 12 {
             return Err(ParseBDAddrError::IncorrectByteCount);
         }
-        if s.bytes().find(|b| !b.is_ascii_hexdigit()).is_some() {
+        if s.bytes().any(|b| !b.is_ascii_hexdigit()) {
             return Err(ParseBDAddrError::InvalidDigit);
         }
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -12,6 +12,7 @@
 // Copyright (c) 2014 The Rust Project Developers
 
 mod adapter_manager;
+mod bdaddr;
 pub mod bleuuid;
 
 use crate::{Error, Result};
@@ -25,10 +26,10 @@ use std::sync::mpsc::Receiver;
 use std::{
     collections::{BTreeSet, HashMap},
     fmt::{self, Debug},
-    str::FromStr,
 };
-use thiserror::Error;
 use uuid::Uuid;
+
+pub use self::bdaddr::BDAddr;
 
 #[cfg_attr(
     feature = "serde",
@@ -69,203 +70,6 @@ impl AddressType {
             AddressType::Public => 1,
             AddressType::Random => 2,
         }
-    }
-}
-
-/// Stores the 6 byte address used to identify Bluetooth devices.
-#[cfg_attr(
-    feature = "serde",
-    derive(Serialize, Deserialize),
-    serde(crate = "serde_cr")
-)]
-#[derive(Copy, Clone, Hash, Eq, PartialEq, Default)]
-#[repr(C)]
-pub struct BDAddr {
-    address: [u8; 6usize],
-}
-
-#[derive(Debug, Error, Clone, PartialEq)]
-pub enum ParseBDAddrError {
-    #[error("Bluetooth address has to be 6 bytes long")]
-    IncorrectByteCount,
-    #[error("All digits in a Bluetooth address must be hex-digits [0-9a-fA-F]")]
-    InvalidDigit,
-}
-
-impl fmt::Display for BDAddr {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        <Self as fmt::LowerHex>::fmt(self, f)
-    }
-}
-
-impl fmt::LowerHex for BDAddr {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let a = &self.address;
-        write!(
-            f,
-            "{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
-            a[0], a[1], a[2], a[3], a[4], a[5]
-        )
-    }
-}
-
-impl fmt::UpperHex for BDAddr {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let a = &self.address;
-        write!(
-            f,
-            "{:02X}:{:02X}:{:02X}:{:02X}:{:02X}:{:02X}",
-            a[0], a[1], a[2], a[3], a[4], a[5]
-        )
-    }
-}
-
-impl fmt::Debug for BDAddr {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        <Self as fmt::Display>::fmt(self, f)
-    }
-}
-
-impl AsRef<[u8]> for BDAddr {
-    fn as_ref(&self) -> &[u8] {
-        &self.address
-    }
-}
-
-impl From<[u8; 6]> for BDAddr {
-    /// Build an address from an array.
-    ///
-    /// `address[0]` will be the MSB and `address[5]` the LSB.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # use btleplug::api::BDAddr;
-    /// let addr: BDAddr = [0x2a, 0xCC, 0x00, 0x34, 0xfa, 0x00].into();
-    /// assert_eq!("2a:cc:00:34:fa:00", addr.to_string());
-    /// ```
-    fn from(address: [u8; 6]) -> Self {
-        Self { address }
-    }
-}
-
-impl<'a> std::convert::TryFrom<&'a [u8]> for BDAddr {
-    type Error = ParseBDAddrError;
-
-    fn try_from(slice: &'a [u8]) -> Result<Self, Self::Error> {
-        if slice.len() < 6 {
-            Err(ParseBDAddrError::IncorrectByteCount)
-        } else {
-            let mut cpy = [0; 6];
-            cpy.copy_from_slice(&slice[..6]);
-            Ok(cpy.into())
-        }
-    }
-}
-
-impl From<u64> for BDAddr {
-    fn from(int: u64) -> Self {
-        let mut cpy = [0; 6];
-        let slice = int.to_be_bytes(); // Reverse order to have MSB on index 0
-        cpy.copy_from_slice(&slice[2..]);
-        cpy.into()
-    }
-}
-
-impl From<BDAddr> for u64 {
-    fn from(addr: BDAddr) -> Self {
-        let mut slice = [0; 8];
-        (&mut slice[2..]).copy_from_slice(&addr.into_inner());
-        u64::from_be_bytes(slice)
-    }
-}
-
-impl From<ParseBDAddrError> for Error {
-    fn from(e: ParseBDAddrError) -> Self {
-        Error::Other(format!("ParseBDAddrError: {}", e))
-    }
-}
-
-impl FromStr for BDAddr {
-    type Err = ParseBDAddrError;
-
-    /// Parses a Bluetooth address of the form `aa:bb:cc:dd:ee:ff` or of form
-    /// `aabbccddeeff`.
-    ///
-    /// All hex-digits `[0-9a-fA-F]` are allowed.
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if s.contains(':') {
-            Self::from_str_delim(s)
-        } else {
-            Self::from_str_no_delim(s)
-        }
-    }
-}
-
-impl BDAddr {
-    pub fn into_inner(self) -> [u8; 6] {
-        self.address
-    }
-    pub fn bytes(&self) -> &[u8; 6] {
-        &self.address
-    }
-    /// Check if this address is a randomly generated.
-    pub fn is_random_static(&self) -> bool {
-        self.address[5] & 0b11 == 0b11
-    }
-    /// Parses a Bluetooth address colons `:` as delimiters.
-    ///
-    /// All hex-digits `[0-9a-fA-F]` are allowed.
-    pub fn from_str_delim(s: &str) -> Result<Self, ParseBDAddrError> {
-        let bytes = s
-            .split(':')
-            .map(|part: &str| {
-                u8::from_str_radix(part, 16).map_err(|_| ParseBDAddrError::InvalidDigit)
-            })
-            .collect::<Result<Vec<u8>, _>>()?;
-
-        if bytes.len() == 6 {
-            let mut address = [0; 6];
-            address.copy_from_slice(bytes.as_slice());
-            Ok(BDAddr { address })
-        } else {
-            Err(ParseBDAddrError::IncorrectByteCount)
-        }
-    }
-    /// Parses a Bluetooth address without delimiters.
-    ///
-    /// All hex-digits `[0-9a-fA-F]` are allowed.
-    pub fn from_str_no_delim(s: &str) -> Result<Self, ParseBDAddrError> {
-        if s.len() != 12 {
-            return Err(ParseBDAddrError::IncorrectByteCount);
-        }
-        if s.bytes().any(|b| !b.is_ascii_hexdigit()) {
-            return Err(ParseBDAddrError::InvalidDigit);
-        }
-
-        let mut address = [0; 6];
-        for i in (0..12).step_by(2) {
-            let part = &s[i..i + 2];
-            address[i / 2] = u8::from_str_radix(part, 16).expect("Checked upfront");
-        }
-        Ok(Self { address })
-    }
-    /// Writes the address without delimiters.
-    pub fn write_flat(&self, f: &mut impl fmt::Write) -> fmt::Result {
-        for b in &self.address {
-            write!(f, "{:02x}", b)?;
-        }
-        Ok(())
-    }
-    /// Create a `String` with the address with no delimiters.
-    ///
-    /// For the more common presentation with colons use the `to_string()`
-    /// method.
-    pub fn to_string_flat(&self) -> String {
-        let mut s = String::with_capacity(12);
-        self.write_flat(&mut s)
-            .expect("A String-Writer never fails");
-        s
     }
 }
 
@@ -510,61 +314,7 @@ pub trait Central: Send + Sync + Clone {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    // use super::*;
 
-    /// A BDAddr with the same value as `HEX`.
-    const ADDR: BDAddr = BDAddr {
-        address: [0x1f, 0x2a, 0x00, 0xcc, 0x22, 0xf1],
-    };
-    /// A u64 with the same value as `ADDR`.
-    const HEX: u64 = 0x00_00_1f_2a_00_cc_22_f1;
-
-    #[test]
-    fn parse_addr() {
-        let bytes = [0x2a, 0x00, 0xaa, 0xbb, 0xcc, 0xdd];
-        let values = vec![
-            ("2a:00:aa:bb:cc:dd", Ok(BDAddr { address: bytes })),
-            ("2a00AabbCcdd", Ok(BDAddr { address: bytes })),
-            ("2A:00:00", Err(ParseBDAddrError::IncorrectByteCount)),
-            ("2A:00:AA:BB:CC:ZZ", Err(ParseBDAddrError::InvalidDigit)),
-            ("2A00aABbcCZz", Err(ParseBDAddrError::InvalidDigit)),
-        ];
-
-        for (input, expected) in values {
-            println!("testing: {}", input);
-            let result: Result<BDAddr, _> = input.parse();
-            assert_eq!(result, expected);
-
-            if let Ok(addr) = result {
-                assert_eq!(bytes, addr.into_inner());
-            }
-        }
-    }
-
-    #[test]
-    fn display_addr() {
-        assert_eq!(format!("{}", ADDR), "1f:2a:00:cc:22:f1");
-        assert_eq!(format!("{:?}", ADDR), "1f:2a:00:cc:22:f1");
-        assert_eq!(format!("{:x}", ADDR), "1f:2a:00:cc:22:f1");
-        assert_eq!(format!("{:X}", ADDR), "1F:2A:00:CC:22:F1");
-        assert_eq!(format!("{}", ADDR.to_string_flat()), "1f2a00cc22f1");
-    }
-
-    #[test]
-    fn u64_to_addr() {
-        let hex_addr: BDAddr = HEX.into();
-        assert_eq!(hex_addr, ADDR);
-
-        let hex_back: u64 = hex_addr.into();
-        assert_eq!(HEX, hex_back);
-    }
-
-    #[test]
-    fn addr_to_u64() {
-        let addr_as_hex: u64 = ADDR.into();
-        assert_eq!(HEX, addr_as_hex);
-
-        let addr_back: BDAddr = addr_as_hex.into();
-        assert_eq!(ADDR, addr_back);
-    }
+    // No tests, yet.
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -205,17 +205,18 @@ impl BDAddr {
     ///
     /// All hex-digits `[0-9a-fA-F]` are allowed.
     pub fn from_str_no_delim(s: &str) -> Result<Self, ParseBDAddrError> {
-        if !s.is_ascii() {
-            return Err(ParseBDAddrError::InvalidDigit);
-        }
-        if s.len() > 12 {
+        if s.len() != 12 {
             return Err(ParseBDAddrError::IncorrectByteCount);
         }
+        if s.bytes().find(|b| !b.is_ascii_hexdigit()).is_some() {
+            return Err(ParseBDAddrError::InvalidDigit);
+        }
+
         let mut address = [0; 6];
         for i in (0..12).step_by(2) {
             let part = &s[i..i + 2];
             address[i / 2] =
-                u8::from_str_radix(part, 16).map_err(|_| ParseBDAddrError::InvalidDigit)?;
+                u8::from_str_radix(part, 16).expect("Checked upfront");
         }
         Ok(Self { address })
     }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -81,7 +81,7 @@ impl AddressType {
 #[derive(Copy, Clone, Hash, Eq, PartialEq, Default)]
 #[repr(C)]
 pub struct BDAddr {
-    pub address: [u8; 6usize],
+    address: [u8; 6usize],
 }
 
 impl fmt::Display for BDAddr {
@@ -124,6 +124,23 @@ impl AsRef<[u8]> for BDAddr {
     }
 }
 
+impl From<[u8; 6]> for BDAddr {
+    /// Build an address from an array.
+    ///
+    /// `address[0]` will be the MSB and `address[5]` the LSB.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use btleplug::api::BDAddr;
+    /// let addr: BDAddr = [0x2a, 0xCC, 0x00, 0x34, 0xfa, 0x00].into();
+    /// assert_eq!("2a:cc:00:34:fa:00", addr.to_string());
+    /// ```
+    fn from(address: [u8; 6]) -> Self {
+        Self { address }
+    }
+}
+
 #[derive(Debug, Error, Clone, PartialEq)]
 pub enum ParseBDAddrError {
     #[error("Bluetooth address has to be 6 bytes long")]
@@ -157,6 +174,13 @@ impl FromStr for BDAddr {
 impl BDAddr {
     pub fn into_inner(self) -> [u8; 6] {
         self.address
+    }
+    pub fn bytes(&self) -> &[u8; 6] {
+        &self.address
+    }
+    /// Check if this address is a randomly generated.
+    pub fn is_random_static(&self) -> bool {
+        self.address[5] & 0b11 == 0b11
     }
     /// Parses a Bluetooth address colons `:` as delimiters.
     ///

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -15,7 +15,7 @@ mod adapter_manager;
 mod bdaddr;
 pub mod bleuuid;
 
-use crate::{Error, Result};
+use crate::Result;
 pub use adapter_manager::AdapterManager;
 use bitflags::bitflags;
 #[cfg(feature = "serde")]
@@ -25,11 +25,11 @@ use serde_cr as serde;
 use std::sync::mpsc::Receiver;
 use std::{
     collections::{BTreeSet, HashMap},
-    fmt::{self, Debug},
+    fmt::{self, Debug, Display, Formatter},
 };
 use uuid::Uuid;
 
-pub use self::bdaddr::BDAddr;
+pub use self::bdaddr::{BDAddr, ParseBDAddrError};
 
 #[cfg_attr(
     feature = "serde",
@@ -136,8 +136,8 @@ pub struct Characteristic {
     pub properties: CharPropFlags,
 }
 
-impl fmt::Display for Characteristic {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+impl Display for Characteristic {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(
             f,
             "uuid: {:?}, char properties: {:?}",
@@ -310,11 +310,4 @@ pub trait Central: Send + Sync + Clone {
     /// Returns a particular [`Peripheral`](trait.Peripheral.html) by its address if it has been
     /// discovered.
     fn peripheral(&self, address: BDAddr) -> Option<Self::Peripheral>;
-}
-
-#[cfg(test)]
-mod tests {
-    // use super::*;
-
-    // No tests, yet.
 }

--- a/src/corebluetooth/adapter.rs
+++ b/src/corebluetooth/adapter.rs
@@ -7,7 +7,7 @@ use futures::channel::mpsc::{self, Sender};
 use futures::sink::SinkExt;
 use futures::stream::StreamExt;
 use log::info;
-use std::convert::TryInto;
+use std::convert::{TryFrom, TryInto};
 use std::sync::mpsc::Receiver;
 
 #[derive(Clone, Debug)]
@@ -17,9 +17,8 @@ pub struct Adapter {
 }
 
 pub(crate) fn uuid_to_bdaddr(uuid: &String) -> BDAddr {
-    BDAddr {
-        address: uuid.as_bytes()[0..6].try_into().unwrap(),
-    }
+    let b: [u8; 6] = uuid.as_bytes()[0..6].try_into().unwrap();
+    BDAddr::try_from(b).unwrap()
 }
 
 impl Adapter {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,6 +73,7 @@
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 extern crate cocoa;
 
+use crate::api::ParseBDAddrError;
 use std::result;
 use std::time::Duration;
 
@@ -105,6 +106,9 @@ pub enum Error {
 
     #[error("Error parsing UUID: {0}")]
     Uuid(#[from] uuid::Error),
+
+    #[error("Invalid Bluetooth address: {0}")]
+    InvalidBDAddr(#[from] ParseBDAddrError),
 
     #[error("{}", _0)]
     Other(String),

--- a/src/winrtble/adapter.rs
+++ b/src/winrtble/adapter.rs
@@ -44,7 +44,7 @@ impl Central for Adapter {
         let manager = self.manager.clone();
         watcher.start(Box::new(move |args| {
             let bluetooth_address = args.bluetooth_address().unwrap();
-            let address = utils::to_addr(bluetooth_address);
+            let address = bluetooth_address.into();
             let peripheral = manager
                 .peripheral(address)
                 .unwrap_or_else(|| Peripheral::new(manager.clone(), address));

--- a/src/winrtble/adapter.rs
+++ b/src/winrtble/adapter.rs
@@ -16,6 +16,7 @@ use crate::{
     api::{AdapterManager, BDAddr, Central, CentralEvent},
     Result,
 };
+use std::convert::TryInto;
 use std::sync::{mpsc::Receiver, Arc, Mutex};
 
 #[derive(Clone)]
@@ -44,7 +45,7 @@ impl Central for Adapter {
         let manager = self.manager.clone();
         watcher.start(Box::new(move |args| {
             let bluetooth_address = args.bluetooth_address().unwrap();
-            let address = bluetooth_address.into();
+            let address = bluetooth_address.try_into().unwrap();
             let peripheral = manager
                 .peripheral(address)
                 .unwrap_or_else(|| Peripheral::new(manager.clone(), address));

--- a/src/winrtble/ble/device.rs
+++ b/src/winrtble/ble/device.rs
@@ -32,7 +32,7 @@ unsafe impl Sync for BLEDevice {}
 
 impl BLEDevice {
     pub fn new(address: BDAddr, connection_status_changed: ConnectedEventHandler) -> Result<Self> {
-        let async_op = BluetoothLEDevice::from_bluetooth_address_async(utils::to_address(address))
+        let async_op = BluetoothLEDevice::from_bluetooth_address_async(address.into())
             .map_err(|_| Error::DeviceNotFound)?;
         let device = async_op.get().map_err(|_| Error::DeviceNotFound)?;
         let connection_status_handler = TypedEventHandler::new(

--- a/src/winrtble/utils.rs
+++ b/src/winrtble/utils.rs
@@ -40,22 +40,6 @@ pub fn to_error(status: GattCommunicationStatus) -> Result<()> {
     }
 }
 
-pub fn to_addr(addr: u64) -> BDAddr {
-    let mut address: [u8; 6usize] = [0, 0, 0, 0, 0, 0];
-    for i in 0..6 {
-        address[i] = (addr >> (8 * i)) as u8;
-    }
-    BDAddr { address }
-}
-
-pub fn to_address(addr: BDAddr) -> u64 {
-    let mut address = 0u64;
-    for i in (0..6).rev() {
-        address |= (u64::from(addr.address[i])) << (8 * i);
-    }
-    address
-}
-
 pub fn to_uuid(uuid: &Guid) -> Uuid {
     let guid_s = format!("{:?}", uuid);
     Uuid::from_str(&guid_s).unwrap()
@@ -85,8 +69,8 @@ mod tests {
     #[test]
     fn check_address() {
         let bluetooth_address = 252566450624623;
-        let addr = to_addr(bluetooth_address);
-        let result = to_address(addr);
+        let addr = bluetooth_address.into();
+        let result = addr.into();
         assert_eq!(bluetooth_address, result);
     }
 

--- a/src/winrtble/utils.rs
+++ b/src/winrtble/utils.rs
@@ -67,14 +67,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn check_address() {
-        let bluetooth_address = 252566450624623;
-        let addr = bluetooth_address.into();
-        let result = addr.into();
-        assert_eq!(bluetooth_address, result);
-    }
-
-    #[test]
     fn check_uuid_to_guid_conversion() {
         let uuid_str = "10B201FF-5B3B-45A1-9508-CF3EFCD7BBAF";
         let uuid = Uuid::from_str(uuid_str).unwrap();


### PR DESCRIPTION
This PR follows the discussion of #68.

At last I found some time to work on this. For now I refactored `BDAddr` as a show case what I intend to do. If the implementation is approved I'll start working on `UUID`. Of course I'll include the changed suggested in #80 as well.

Initially, I wanted to write the parsers with `nom` but I recognized that there is a bunch of `nom v4` code in the crate so I settled for a 'hand-crafted' version. Another solution would be to use `regex` but I didn't wanted to pull in another dependency without asking.