### PR TITLE
CoreBluetooth async Disconnect, Pending Connect, Discover Characteristics

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,7 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.148.1/containers/rust/.devcontainer/base.Dockerfile
+
+FROM mcr.microsoft.com/vscode/devcontainers/rust:0-1
+
+# [Optional] Uncomment this section to install additional packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,34 @@
+{
+	"name": "Rust",
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
+	"runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash",
+		"lldb.executable": "/usr/bin/lldb",
+		// VS Code don't watch files under ./target
+		"files.watcherExclude": {
+			"**/target/**": true
+		}
+	},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"rust-lang.rust",
+		"bungcip.better-toml",
+		"vadimcn.vscode-lldb",
+		"mutantdino.resourcemonitor"
+	],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "rustc --version",
+
+	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "vscode"
+}

--- a/examples/event_driven_discovery.rs
+++ b/examples/event_driven_discovery.rs
@@ -61,17 +61,24 @@ pub fn main() {
                 let characteristic_uuid: UUID = "00:00".parse().unwrap();
                 if let Some(peripheral) = central.peripheral(bd_addr) {
                     let peripheral_clone = peripheral.clone();
-                    peripheral.on_discovery(characteristic_uuid, Box::new(move |characteristic| {
-                        println!("I found the characteristic I was looking for: {:?}", characteristic);
-                        let another_clone = peripheral_clone.clone();
-                        task::spawn(async move {
-                            loop {
-                                let value: Result<Vec<u8>, _> = another_clone.read(&characteristic);
-                                println!("I read the value: {:?}", value);
-                                task::sleep(std::time::Duration::from_secs(1)).await;
-                            }
-                        });
-                    }));
+                    peripheral.on_discovery(
+                        characteristic_uuid,
+                        Box::new(move |characteristic| {
+                            println!(
+                                "I found the characteristic I was looking for: {:?}",
+                                characteristic
+                            );
+                            let another_clone = peripheral_clone.clone();
+                            task::spawn(async move {
+                                loop {
+                                    let value: Result<Vec<u8>, _> =
+                                        another_clone.read(&characteristic);
+                                    println!("I read the value: {:?}", value);
+                                    task::sleep(std::time::Duration::from_secs(1)).await;
+                                }
+                            });
+                        }),
+                    );
                 }
             }
             CentralEvent::DeviceDisconnected(bd_addr) => {

--- a/src/api/adapter_manager.rs
+++ b/src/api/adapter_manager.rs
@@ -57,15 +57,7 @@ where
 
     pub fn emit(&self, event: CentralEvent) {
         //debug!("emitted {:?}", event);
-        match event {
-            CentralEvent::DeviceDisconnected(addr) => {
-                self.peripherals.remove(&addr);
-            }
-            CentralEvent::DeviceLost(addr) => {
-                self.peripherals.remove(&addr);
-            }
-            _ => {}
-        }
+
         // Since we hold a receiver, this will never fail unless we fill the
         // channel. Whether that's a good idea is another question entirely.
         self.event_sender.lock().unwrap().send(event).unwrap();
@@ -86,6 +78,10 @@ where
         );
         assert_eq!(peripheral.address(), addr, "Device has unexpected address."); // TODO remove addr argument
         self.peripherals.insert(addr, peripheral);
+    }
+
+    pub fn remove_peripheral(&self, addr: &BDAddr) {
+        self.peripherals.remove(addr);
     }
 
     pub fn update_peripheral(&self, addr: BDAddr, peripheral: PeripheralType) {

--- a/src/bluez/adapter/acl_stream.rs
+++ b/src/bluez/adapter/acl_stream.rs
@@ -253,7 +253,7 @@ impl ACLStream {
                     .and_then(|h| self.get_uuid_by_handle(h))
                     .expect("How did we get here without a handle?");
 
-                util::invoke_handlers(&self.notification_handlers, &n);
+                util::invoke_notification_handlers(&self.notification_handlers, &n);
             }
             Err(err) => {
                 error!("failed to parse notification: {:?}", err);

--- a/src/bluez/adapter/peripheral.rs
+++ b/src/bluez/adapter/peripheral.rs
@@ -14,8 +14,8 @@
 use crate::{
     api::{
         AddressType, BDAddr, Callback, Central, CharPropFlags, Characteristic, CommandCallback,
-        NotificationHandler, Peripheral as ApiPeripheral, PeripheralProperties, RequestCallback,
-        UUID, UUID::B16,
+        DiscoveryHandler, NotificationHandler, Peripheral as ApiPeripheral, PeripheralProperties,
+        RequestCallback, UUID, UUID::B16,
     },
     bluez::{
         adapter::acl_stream::ACLStream,
@@ -508,6 +508,11 @@ impl ApiPeripheral for Peripheral {
 
     fn discover_characteristics(&self) -> Result<Vec<Characteristic>> {
         self.discover_characteristics_in_range(0x0001, 0xFFFF)
+    }
+
+    fn on_discovery(&self, characteristic_uuid: UUID, handler: DiscoveryHandler) {
+        // Characteristic discovery is synchronous for the bluez implementation
+        unimplemented!();
     }
 
     fn discover_characteristics_in_range(

--- a/src/common/util.rs
+++ b/src/common/util.rs
@@ -5,9 +5,9 @@
 // Licensed under the BSD 3-Clause license. See LICENSE file in the project root
 // for full license information.
 
-use crate::api::{UUID, ValueNotification, CharacteristicsDiscovery, Characteristic};
-use std::sync::{Arc, Mutex};
+use crate::api::{Characteristic, CharacteristicsDiscovery, ValueNotification, UUID};
 use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
 
 pub fn invoke_notification_handlers<F: FnMut(ValueNotification) + ?Sized>(
     notification_handlers: &Arc<Mutex<Vec<Box<F>>>>,

--- a/src/corebluetooth/adapter.rs
+++ b/src/corebluetooth/adapter.rs
@@ -60,11 +60,19 @@ impl Adapter {
                         let id = uuid_to_bdaddr(&uuid.to_string());
                         emit(CentralEvent::DeviceUpdated(id));
                     },
-                    */
-                    CoreBluetoothEvent::DeviceLost(uuid) => {
+                    CoreBluetoothEvent::DeviceConnected(uuid) => {
+                        let id = uuid_to_bdaddr(&uuid.to_string());
+                        manager_clone.emit(CentralEvent::DeviceConnected(id));
+                    }
+                    CoreBluetoothEvent::DeviceDisconnected(uuid) => {
                         let id = uuid_to_bdaddr(&uuid.to_string());
                         manager_clone.emit(CentralEvent::DeviceDisconnected(id));
                     }
+                    CoreBluetoothEvent::DeviceLost(uuid) => {
+                        let id = uuid_to_bdaddr(&uuid.to_string());
+                        manager_clone.emit(CentralEvent::DeviceLost(id));
+                    }
+                    */
                     _ => {}
                 }
             }

--- a/src/corebluetooth/central_delegate.rs
+++ b/src/corebluetooth/central_delegate.rs
@@ -254,7 +254,6 @@ pub mod CentralDelegate {
             CoreBluetoothUtils::peripheral_debug(peripheral)
         );
         cb::peripheral_setdelegate(peripheral, delegate);
-        cb::peripheral_discoverservices(peripheral);
         let uuid_nsstring = ns::uuid_uuidstring(cb::peer_identifier(peripheral));
         let uuid = Uuid::from_str(&NSStringUtils::string_to_string(uuid_nsstring)).unwrap();
         send_delegate_event(delegate, CentralDelegateEvent::ConnectedDevice(uuid));

--- a/src/corebluetooth/internal.rs
+++ b/src/corebluetooth/internal.rs
@@ -153,7 +153,9 @@ impl CBPeripheral {
             char_set.insert(char);
         }
         task::block_on(async {
-            self.event_sender.send(CBPeripheralEvent::DiscoveredCharacteristics(char_set)).await;
+            self.event_sender
+                .send(CBPeripheralEvent::DiscoveredCharacteristics(char_set))
+                .await;
         });
     }
 
@@ -322,7 +324,7 @@ impl CoreBluetoothInternal {
                 .unwrap()
                 .set_reply(CoreBluetoothReply::Ok);
         }
-   }
+    }
 
     fn on_characteristic_subscribed(&mut self, peripheral_uuid: Uuid, characteristic_uuid: Uuid) {
         if let Some(p) = self.peripherals.get_mut(&peripheral_uuid) {
@@ -409,7 +411,11 @@ impl CoreBluetoothInternal {
         }
     }
 
-    fn discover_characteristics(&mut self, peripheral_uuid: Uuid, fut: CoreBluetoothReplyStateShared) {
+    fn discover_characteristics(
+        &mut self,
+        peripheral_uuid: Uuid,
+        fut: CoreBluetoothReplyStateShared,
+    ) {
         info!("Trying to discover characteristics!");
         if let Some(p) = self.peripherals.get_mut(&peripheral_uuid) {
             cb::peripheral_discoverservices(*p.peripheral);
@@ -417,9 +423,7 @@ impl CoreBluetoothInternal {
             // We may not know how many characteristics/services we will discover.
             // In succeeding this future, we are marking that we completed requesting discovery
             // and there may be existing characteristics/services already discovered.
-            fut.lock()
-                .unwrap()
-                .set_reply(CoreBluetoothReply::Ok);
+            fut.lock().unwrap().set_reply(CoreBluetoothReply::Ok);
         }
     }
 
@@ -460,7 +464,7 @@ impl CoreBluetoothInternal {
                 error!("Unknown characteristic");
             }
         } else {
-                error!("Unknown peripheral");
+            error!("Unknown peripheral");
         }
     }
 

--- a/src/corebluetooth/peripheral.rs
+++ b/src/corebluetooth/peripheral.rs
@@ -13,9 +13,10 @@ use super::{
 };
 use crate::{
     api::{
-        AdapterManager, AddressType, BDAddr, CentralEvent, Characteristic, CommandCallback,
-        NotificationHandler, DiscoveryHandler, Peripheral as ApiPeripheral, PeripheralProperties, RequestCallback,
-        ValueNotification, CharacteristicsDiscovery, UUID,
+        AdapterManager, AddressType, BDAddr, CentralEvent, Characteristic,
+        CharacteristicsDiscovery, CommandCallback, DiscoveryHandler, NotificationHandler,
+        Peripheral as ApiPeripheral, PeripheralProperties, RequestCallback, ValueNotification,
+        UUID,
     },
     common::util,
     Error, Result,
@@ -91,20 +92,20 @@ impl Peripheral {
                                 value: data,
                             },
                         );
-                    },
+                    }
                     Some(CBPeripheralEvent::DiscoveredCharacteristics(char_set)) => {
                         info!("Peripheral received discovery of characteristics event");
                         util::invoke_discovery_handlers(
                             &dh_clone,
                             &CharacteristicsDiscovery {
-                                characteristics_set: char_set
-                            }
+                                characteristics_set: char_set,
+                            },
                         );
-                    },
+                    }
                     None => {
                         error!("Event receiver died, breaking out of corebluetooth device loop.");
                         break;
-                    },
+                    }
                 }
             }
         });
@@ -220,7 +221,7 @@ impl ApiPeripheral for Peripheral {
                 CoreBluetoothReply::Ok => {
                     self.emit(CentralEvent::DeviceDisconnected(self.properties.address));
                 }
-                _ => info!("Disconnect shouldn't get anything but ok")
+                _ => info!("Disconnect shouldn't get anything but ok"),
             }
         });
         info!("Device disconnected!");
@@ -255,7 +256,7 @@ impl ApiPeripheral for Peripheral {
                 if !handlers.contains_key(&characteristic_uuid) {
                     handlers.insert(characteristic_uuid, handler);
                 }
-            },
+            }
             _ => {
                 info!("Discovery handlers lock is contended, skipping");
             }

--- a/src/winrtble/peripheral.rs
+++ b/src/winrtble/peripheral.rs
@@ -230,6 +230,11 @@ impl ApiPeripheral for Peripheral {
         Err(Error::NotConnected)
     }
 
+    fn on_discovery(&self, characteristic_uuid: UUID, handler: DiscoveryHandler) {
+        // Characteristic discovery is synchronous for the winrtble implementation
+        unimplemented!();
+    }
+
     /// Discovers characteristics within the specified range of handles. This is a synchronous
     /// operation.
     fn discover_characteristics_in_range(

--- a/src/winrtble/peripheral.rs
+++ b/src/winrtble/peripheral.rs
@@ -15,7 +15,7 @@ use super::{ble::characteristic::BLECharacteristic, ble::device::BLEDevice, util
 use crate::{
     api::{
         AdapterManager, AddressType, BDAddr, CentralEvent, Characteristic, CommandCallback,
-        NotificationHandler, Peripheral as ApiPeripheral, PeripheralProperties, RequestCallback,
+        NotificationHandler, DiscoveryHandler, Peripheral as ApiPeripheral, PeripheralProperties, RequestCallback,
         ValueNotification, UUID,
     },
     common::util,
@@ -319,7 +319,7 @@ impl ApiPeripheral for Peripheral {
                     handle: None,
                     value,
                 };
-                util::invoke_handlers(&notification_handlers, &notification);
+                util::invoke_notification_handlers(&notification_handlers, &notification);
             }))
         } else {
             Err(Error::NotSupported("subscribe".into()))


### PR DESCRIPTION
In CoreBluetooth, disconnecting from a peripheral must not remove the Peripheral in order to set a pending connection. Since we don't have the whole of CoreBluetooth's async callbacks, we must separate and loosen some of the synchronous APIs that are exposed by the current Rust Peripheral abstraction. I am not saying that there shouldn't be nice synchronous abstractions, just that the current level prevents some use cases that I would consider to be standard.

I have the following use case that is supported on macOS by these changes.
* Begin scanning indefinitely with async event receiver
* Filter discovered peripherals by name
* Connect to a peripheral by bd_addr
* Set callbacks for the discovery of specific characteristics that use synchronous `api::Peripheral` methods `read` and `write`
* Initiate disconnection from the peripheral after a period of time
* Initiate a pending connection to the peripheral after another period of time
* Re-connect and repeat starting at setting callbacks

I suspect that the windows and Linux variants of this interface are invalidated by this change but have not verified.
- [ ] Don't break windows
- [ ] Don't break linux
- [ ] Gracefully handle remote peripheral disconnection
- [ ] Document api change