### PR TITLE
Allow pub access to btleplug::bluez::adapter::peripheral::Peripheral

### DIFF
--- a/src/bluez/adapter/mod.rs
+++ b/src/bluez/adapter/mod.rs
@@ -12,7 +12,7 @@
 // Copyright (c) 2014 The Rust Project Developers
 
 mod acl_stream;
-mod peripheral;
+pub mod peripheral;
 
 use bytes::{BufMut, BytesMut};
 use dashmap::DashMap;


### PR DESCRIPTION
The peripheral module is private but the Peripheral struct is public

Allows external reference to concrete type, ie
```rust
pub enum PMessage<P: btleplug::api::Peripheral> {
    Foo(P),
    Bar(P),
    Ok,
}

#[cfg(target_os = "macos")]
type Message = PMessage<btleplug::corebluetooth::peripheral::Peripheral>;

#[cfg(target_os = "linux")]
type Message = PMessage<btleplug::bluez::adapter::peripheral::Peripheral>;
```