### PR TITLE
Store services on PeripheralProperties

### DIFF
--- a/examples/event_driven_discovery.rs
+++ b/examples/event_driven_discovery.rs
@@ -52,7 +52,12 @@ pub fn main() {
     while let Ok(event) = event_receiver.recv() {
         match event {
             CentralEvent::DeviceDiscovered(bd_addr) => {
-                println!("DeviceDiscovered: {:?}", bd_addr);
+                println!(
+                    "DeviceDiscovered: {:?}",
+                    central
+                        .peripheral(bd_addr)
+                        .expect("Couldn't get discovered device from central")
+                );
             }
             CentralEvent::DeviceConnected(bd_addr) => {
                 println!("DeviceConnected: {:?}", bd_addr);

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -277,6 +277,8 @@ pub struct PeripheralProperties {
     pub tx_power_level: Option<i8>,
     /// Unstructured data set by the device manufacturer
     pub manufacturer_data: Option<Vec<u8>>,
+    /// Service Identifiers
+    pub services: BTreeSet<UUID>,
     /// Number of times we've seen advertising reports for this device
     pub discovery_count: u32,
     /// True if we've discovered the device before

--- a/src/bluez/adapter/peripheral.rs
+++ b/src/bluez/adapter/peripheral.rs
@@ -179,6 +179,12 @@ impl Peripheral {
                         &ManufacturerSpecific(ref data) => {
                             properties.manufacturer_data = Some(data.clone());
                         }
+                        &ServiceClassUUID16(ref data) => {
+                            properties.services.insert(UUID::B16(*data));
+                        }
+                        &ServiceClassUUID128(ref data) => {
+                            properties.services.insert(UUID::B128(*data));
+                        }
                         _ => {
                             // skip for now
                         }

--- a/src/corebluetooth/peripheral.rs
+++ b/src/corebluetooth/peripheral.rs
@@ -67,6 +67,7 @@ impl Peripheral {
             manufacturer_data: None,
             discovery_count: 1,
             has_scan_response: true,
+            services: BTreeSet::new(),
         };
         let notification_handlers = Arc::new(Mutex::new(Vec::<NotificationHandler>::new()));
         let mut er_clone = event_receiver.clone();


### PR DESCRIPTION
In my use case (brew / home automation) I would like to be able to be monitoring devices as they become available, and do different things based on their advertised data. One of the facets of that data that is useful to act on, is the service id exposed by the device.

I saw a previous PR (https://github.com/deviceplug/btleplug/pull/23) that attempted to make more information available, but that was limited to bluez only.

I *think* the way things are intended to work, is that the `DeviceDiscovered` event just gives the address of the discovered advice, and then if someone wants more details, they can get the device, and use its `PeripheralProperties` to access the advertising data, therefore, this PR just extends PeripheralProperties with a BTreeSet of services, and (currently only for bluez) populates it when advertising information is available.

I've also changed the discovery example to show retrieving the device based on the address.

If this is the right approach, I can look at adding similar functionality for Windows and macOS too.