### PR TITLE
Store service data on PeripheralProperties

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -23,7 +23,7 @@ use crate::{
 use serde::{Deserialize, Serialize};
 use std::sync::mpsc::Receiver;
 use std::{
-    collections::BTreeSet,
+    collections::{BTreeSet, BTreeMap},
     convert::TryFrom,
     fmt::{self, Debug, Display, Formatter},
     str::FromStr,
@@ -277,6 +277,8 @@ pub struct PeripheralProperties {
     pub tx_power_level: Option<i8>,
     /// Unstructured data set by the device manufacturer
     pub manufacturer_data: Option<Vec<u8>>,
+    /// Service data set by the device manufacturer
+    pub service_data: BTreeMap<UUID, Vec<u8>>,
     /// Number of times we've seen advertising reports for this device
     pub discovery_count: u32,
     /// True if we've discovered the device before

--- a/src/bluez/adapter/peripheral.rs
+++ b/src/bluez/adapter/peripheral.rs
@@ -179,6 +179,16 @@ impl Peripheral {
                         &ManufacturerSpecific(ref data) => {
                             properties.manufacturer_data = Some(data.clone());
                         }
+                        &ServiceData16(ref uuid, ref data) => {
+                            properties
+                                .service_data
+                                .insert(UUID::B16(*uuid), data.clone());
+                        }
+                        &ServiceData128(ref uuid, ref data) => {
+                            properties
+                                .service_data
+                                .insert(UUID::B128(*uuid), data.clone());
+                        }
                         _ => {
                             // skip for now
                         }

--- a/src/corebluetooth/peripheral.rs
+++ b/src/corebluetooth/peripheral.rs
@@ -26,7 +26,7 @@ use async_std::{
     task,
 };
 use std::{
-    collections::BTreeSet,
+    collections::{BTreeSet, BTreeMap},
     fmt::{self, Debug, Display, Formatter},
     iter::FromIterator,
     sync::{Arc, Mutex},
@@ -65,6 +65,7 @@ impl Peripheral {
             local_name: Some(local_name),
             tx_power_level: None,
             manufacturer_data: None,
+            service_data: BTreeMap::new(),
             discovery_count: 1,
             has_scan_response: true,
         };


### PR DESCRIPTION
Spiritual successor (for my use case) of #23, inspired by #96.

Currently only implemented for bluez, but the approach should be easy to implement for the other backends.