### PR TITLE
move Peripheral from general parameter to associated type for Central

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -347,7 +347,9 @@ pub enum CentralEvent {
 }
 
 /// Central is the "client" of BLE. It's able to scan for and establish connections to peripherals.
-pub trait Central<P: Peripheral>: Send + Sync + Clone {
+pub trait Central: Send + Sync + Clone {
+    type Peripheral: Peripheral;
+
     /// Retreive the Event [Receiver] for the event channel. This channel
     /// receiver will receive notifications when events occur for this Central
     /// module. As this uses an std::channel which cannot be cloned, after the
@@ -376,11 +378,11 @@ pub trait Central<P: Peripheral>: Send + Sync + Clone {
 
     /// Returns the list of [`Peripherals`](trait.Peripheral.html) that have been discovered so far.
     /// Note that this list may contain peripherals that are no longer available.
-    fn peripherals(&self) -> Vec<P>;
+    fn peripherals(&self) -> Vec<Self::Peripheral>;
 
     /// Returns a particular [`Peripheral`](trait.Peripheral.html) by its address if it has been
     /// discovered.
-    fn peripheral(&self, address: BDAddr) -> Option<P>;
+    fn peripheral(&self, address: BDAddr) -> Option<Self::Peripheral>;
 }
 
 #[cfg(test)]

--- a/src/bluez/adapter/mod.rs
+++ b/src/bluez/adapter/mod.rs
@@ -409,7 +409,9 @@ impl Drop for Adapter {
     }
 }
 
-impl Central<Peripheral> for Adapter {
+impl Central for Adapter {
+    type Peripheral = Peripheral;
+
     fn event_receiver(&self) -> Option<Receiver<CentralEvent>> {
         self.manager.event_receiver()
     }

--- a/src/corebluetooth/adapter.rs
+++ b/src/corebluetooth/adapter.rs
@@ -81,7 +81,9 @@ impl Adapter {
     }
 }
 
-impl Central<Peripheral> for Adapter {
+impl Central for Adapter {
+    type Peripheral = Peripheral;
+
     fn event_receiver(&self) -> Option<Receiver<CentralEvent>> {
         self.manager.event_receiver()
     }

--- a/src/winrtble/adapter.rs
+++ b/src/winrtble/adapter.rs
@@ -32,7 +32,9 @@ impl Adapter {
     }
 }
 
-impl Central<Peripheral> for Adapter {
+impl Central for Adapter {
+    type Peripheral = Peripheral;
+
     fn event_receiver(&self) -> Option<Receiver<CentralEvent>> {
         self.manager.event_receiver()
     }


### PR DESCRIPTION
With both `Adapter` and `Peripheral` being platform specific, I can't see any situation where you would want to implement `Central` more than once for a single `Adapter` but with different `Peripheral`s.

By removing the generic parameter instead it makes the trait easier to work with in generics.