### PR TITLE
unify api usage between platforms a bit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,12 +31,12 @@ uuid = "0.8.2"
 serde_cr = { package = "serde", version = "1.0.123", features = ["derive"], default-features = false, optional = true }
 dashmap = "4.0.2"
 futures = "0.3.12"
+static_assertions = "1.1.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 dbus = "0.9.1"
 displaydoc = "0.1.7"
 parking_lot = "0.11.1"
-static_assertions = "1.1.0"
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 async-std = "1.9.0"

--- a/examples/discover_adapters_peripherals.rs
+++ b/examples/discover_adapters_peripherals.rs
@@ -1,8 +1,4 @@
-#[allow(unused_imports)]
-use rand::{thread_rng, Rng};
 use simple_logger::SimpleLogger;
-#[allow(dead_code)]
-#[allow(unused_imports)]
 use std::thread;
 use std::time::Duration;
 

--- a/examples/discover_adapters_peripherals.rs
+++ b/examples/discover_adapters_peripherals.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use btleplug::{
     api::{Central, Peripheral},
-    Adapter, Manager,
+    platform::{Adapter, Manager},
 };
 
 #[cfg(target_os = "linux")]

--- a/examples/discover_adapters_peripherals.rs
+++ b/examples/discover_adapters_peripherals.rs
@@ -6,17 +6,10 @@ use simple_logger::SimpleLogger;
 use std::thread;
 use std::time::Duration;
 
-#[allow(unused_imports)]
-use btleplug::api::{Central, Characteristic, Peripheral};
-#[allow(unused_imports)]
-#[cfg(target_os = "linux")]
-use btleplug::bluez::{adapter::Adapter, manager::Manager};
-#[allow(unused_imports)]
-#[cfg(target_os = "macos")]
-use btleplug::corebluetooth::{adapter::Adapter, manager::Manager};
-#[allow(unused_imports)]
-#[cfg(target_os = "windows")]
-use btleplug::winrtble::{adapter::Adapter, manager::Manager};
+use btleplug::{
+    api::{Central, Peripheral},
+    Adapter, Manager,
+};
 
 #[cfg(target_os = "linux")]
 fn print_adapter_info(adapter: &Adapter) {

--- a/examples/event_driven_discovery.rs
+++ b/examples/event_driven_discovery.rs
@@ -1,5 +1,5 @@
 use btleplug::api::{bleuuid::BleUuid, Central, CentralEvent};
-use btleplug::{Adapter, Manager};
+use btleplug::platform::{Adapter, Manager};
 
 fn get_central(manager: &Manager) -> Adapter {
     let adapters = manager.adapters().unwrap();

--- a/examples/event_driven_discovery.rs
+++ b/examples/event_driven_discovery.rs
@@ -2,15 +2,7 @@ extern crate btleplug;
 extern crate rand;
 
 use btleplug::api::{bleuuid::BleUuid, Central, CentralEvent};
-#[cfg(target_os = "linux")]
-use btleplug::bluez::{adapter::Adapter, manager::Manager};
-#[cfg(target_os = "macos")]
-use btleplug::corebluetooth::{adapter::Adapter, manager::Manager};
-#[cfg(target_os = "windows")]
-use btleplug::winrtble::{adapter::Adapter, manager::Manager};
-
-// adapter retrieval works differently depending on your platform right now.
-// API needs to be aligned.
+use btleplug::{Adapter, Manager};
 
 fn get_central(manager: &Manager) -> Adapter {
     let adapters = manager.adapters().unwrap();

--- a/examples/event_driven_discovery.rs
+++ b/examples/event_driven_discovery.rs
@@ -1,6 +1,3 @@
-extern crate btleplug;
-extern crate rand;
-
 use btleplug::api::{bleuuid::BleUuid, Central, CentralEvent};
 use btleplug::{Adapter, Manager};
 

--- a/examples/lights.rs
+++ b/examples/lights.rs
@@ -1,13 +1,10 @@
 extern crate btleplug;
 extern crate rand;
 
-use btleplug::api::{bleuuid::uuid_from_u16, Central, Peripheral, WriteType};
-#[cfg(target_os = "linux")]
-use btleplug::bluez::manager::Manager;
-#[cfg(target_os = "macos")]
-use btleplug::corebluetooth::manager::Manager;
-#[cfg(target_os = "windows")]
-use btleplug::winrtble::manager::Manager;
+use btleplug::{
+    api::{bleuuid::uuid_from_u16, Central, Peripheral, WriteType},
+    Manager,
+};
 use rand::{thread_rng, Rng};
 use std::thread;
 use std::time::Duration;

--- a/examples/lights.rs
+++ b/examples/lights.rs
@@ -1,6 +1,3 @@
-extern crate btleplug;
-extern crate rand;
-
 use btleplug::{
     api::{bleuuid::uuid_from_u16, Central, Peripheral, WriteType},
     Manager,

--- a/examples/lights.rs
+++ b/examples/lights.rs
@@ -1,6 +1,6 @@
 use btleplug::{
     api::{bleuuid::uuid_from_u16, Central, Peripheral, WriteType},
-    Manager,
+    platform::Manager,
 };
 use rand::{thread_rng, Rng};
 use std::thread;

--- a/src/bluez/adapter/mod.rs
+++ b/src/bluez/adapter/mod.rs
@@ -201,7 +201,7 @@ impl Adapter {
         );
     }
 
-    pub fn proxy(&self) -> Proxy<&SyncConnection> {
+    pub(crate) fn proxy(&self) -> Proxy<&SyncConnection> {
         self.connection
             .with_proxy(BLUEZ_DEST, &self.path, DEFAULT_TIMEOUT)
     }

--- a/src/bluez/adapter/mod.rs
+++ b/src/bluez/adapter/mod.rs
@@ -13,7 +13,7 @@
 
 // mod acl_stream;
 // mod dbus;
-mod peripheral;
+pub mod peripheral;
 
 use super::{
     bluez_dbus::adapter::OrgBluezAdapter1, bluez_dbus::device::OrgBluezDevice1Properties,

--- a/src/bluez/adapter/peripheral.rs
+++ b/src/bluez/adapter/peripheral.rs
@@ -64,7 +64,7 @@ pub struct Peripheral {
 }
 
 impl Peripheral {
-    pub fn new(
+    pub(crate) fn new(
         adapter: AdapterManager<Self>,
         connection: Arc<SyncConnection>,
         path: &str,
@@ -92,7 +92,7 @@ impl Peripheral {
         }
     }
 
-    pub fn properties_changed(
+    pub(crate) fn properties_changed(
         &self,
         args: PropertiesPropertiesChanged,
         _connection: &SyncConnection,
@@ -145,7 +145,7 @@ impl Peripheral {
         true
     }
 
-    pub fn listen(&self, listener: &SyncConnection) -> Result<()> {
+    pub(crate) fn listen(&self, listener: &SyncConnection) -> Result<()> {
         let peripheral = self.clone();
         let mut rule = PropertiesPropertiesChanged::match_rule(None, None);
         // For some silly lifetime reasons, we need to assign path separately...
@@ -159,7 +159,7 @@ impl Peripheral {
         Ok(())
     }
 
-    pub fn stop_listening(&self, listener: &SyncConnection) -> Result<()> {
+    pub(crate) fn stop_listening(&self, listener: &SyncConnection) -> Result<()> {
         trace!("Stop listening for events");
         let mut token = self.listen_token.lock().unwrap();
         if token.is_some() {
@@ -170,7 +170,12 @@ impl Peripheral {
         Ok(())
     }
 
-    pub fn add_attribute(&self, path: &str, uuid: Uuid, properties: CharPropFlags) -> Result<()> {
+    pub(crate) fn add_attribute(
+        &self,
+        path: &str,
+        uuid: Uuid,
+        properties: CharPropFlags,
+    ) -> Result<()> {
         trace!(
             "Adding attribute {} ({:?}) under {}",
             uuid,
@@ -236,7 +241,7 @@ impl Peripheral {
         Ok(())
     }
 
-    pub fn update_properties(&self, args: OrgBluezDevice1Properties) {
+    pub(crate) fn update_properties(&self, args: OrgBluezDevice1Properties) {
         trace!("Updating peripheral properties");
         let mut properties = self.properties.lock().unwrap();
         let mut emit_updated = false;
@@ -363,12 +368,15 @@ impl Peripheral {
         }
     }
 
-    pub fn proxy(&self) -> Proxy<&SyncConnection> {
+    pub(crate) fn proxy(&self) -> Proxy<&SyncConnection> {
         self.connection
             .with_proxy(BLUEZ_DEST, &self.path, DEFAULT_TIMEOUT)
     }
 
-    pub fn proxy_for(&self, characteristic: &Characteristic) -> Option<Proxy<&SyncConnection>> {
+    pub(crate) fn proxy_for(
+        &self,
+        characteristic: &Characteristic,
+    ) -> Option<Proxy<&SyncConnection>> {
         let map = self.attributes_map.lock().unwrap();
         map.get(&characteristic.value_handle).map(|(path, _h, _c)| {
             self.connection

--- a/src/bluez/manager/mod.rs
+++ b/src/bluez/manager/mod.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 
 /// This struct is the interface into BlueZ. It can be used to list, manage, and connect to bluetooth
 /// adapters.
+#[derive(Clone)]
 pub struct Manager {
     dbus_conn: Arc<SyncConnection>,
 }

--- a/src/corebluetooth/adapter.rs
+++ b/src/corebluetooth/adapter.rs
@@ -16,14 +16,14 @@ pub struct Adapter {
     sender: Sender<CoreBluetoothMessage>,
 }
 
-pub fn uuid_to_bdaddr(uuid: &String) -> BDAddr {
+pub(crate) fn uuid_to_bdaddr(uuid: &String) -> BDAddr {
     BDAddr {
         address: uuid.as_bytes()[0..6].try_into().unwrap(),
     }
 }
 
 impl Adapter {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         let (sender, mut receiver) = mpsc::channel(256);
         let adapter_sender = run_corebluetooth_thread(sender);
         // Since init currently blocked until the state update, we know the

--- a/src/corebluetooth/peripheral.rs
+++ b/src/corebluetooth/peripheral.rs
@@ -46,7 +46,7 @@ pub struct Peripheral {
 }
 
 impl Peripheral {
-    pub fn new(
+    pub(crate) fn new(
         uuid: Uuid,
         local_name: Option<String>,
         manager: AdapterManager<Self>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,6 +93,16 @@ pub mod corebluetooth;
 #[cfg(target_os = "windows")]
 pub mod winrtble;
 
+#[allow(unused_imports)]
+#[cfg(target_os = "linux")]
+pub use crate::bluez::{adapter::Adapter, manager::Manager};
+#[allow(unused_imports)]
+#[cfg(target_os = "macos")]
+pub use crate::corebluetooth::{adapter::Adapter, manager::Manager};
+#[allow(unused_imports)]
+#[cfg(target_os = "windows")]
+pub use crate::winrtble::{adapter::Adapter, manager::Manager};
+
 #[derive(Debug, thiserror::Error, Clone)]
 pub enum Error {
     #[error("Permission denied")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,19 +23,11 @@
 //! use std::thread;
 //! use std::time::Duration;
 //! use rand::{Rng, thread_rng};
-//! #[cfg(target_os = "linux")]
-//! use btleplug::bluez::{adapter::Adapter, manager::Manager};
-//! #[cfg(target_os = "windows")]
-//! use btleplug::winrtble::{adapter::Adapter, manager::Manager};
-//! #[cfg(target_os = "macos")]
-//! use btleplug::corebluetooth::{adapter::Adapter, manager::Manager};
 //! use btleplug::api::{bleuuid::uuid_from_u16, Central, Peripheral, WriteType};
+//! use btleplug::platform::{Adapter, Manager};
 //! use uuid::Uuid;
 //!
 //! const LIGHT_CHARACTERISTIC_UUID: Uuid = uuid_from_u16(0xFFE9);
-//!
-//! // adapter retreival works differently depending on your platform right now.
-//! // API needs to be aligned.
 //!
 //! pub fn main() {
 //!     let manager = Manager::new().unwrap();
@@ -90,15 +82,9 @@ pub mod bluez;
 mod common;
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 pub mod corebluetooth;
+pub mod platform;
 #[cfg(target_os = "windows")]
 pub mod winrtble;
-
-#[cfg(target_os = "linux")]
-pub use crate::bluez::{adapter::Adapter, manager::Manager};
-#[cfg(any(target_os = "macos", target_os = "ios"))]
-pub use crate::corebluetooth::{adapter::Adapter, manager::Manager};
-#[cfg(target_os = "windows")]
-pub use crate::winrtble::{adapter::Adapter, manager::Manager};
 
 #[derive(Debug, thiserror::Error, Clone)]
 pub enum Error {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,7 @@ pub mod winrtble;
 
 #[cfg(target_os = "linux")]
 pub use crate::bluez::{adapter::Adapter, manager::Manager};
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 pub use crate::corebluetooth::{adapter::Adapter, manager::Manager};
 #[cfg(target_os = "windows")]
 pub use crate::winrtble::{adapter::Adapter, manager::Manager};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,13 +93,10 @@ pub mod corebluetooth;
 #[cfg(target_os = "windows")]
 pub mod winrtble;
 
-#[allow(unused_imports)]
 #[cfg(target_os = "linux")]
 pub use crate::bluez::{adapter::Adapter, manager::Manager};
-#[allow(unused_imports)]
 #[cfg(target_os = "macos")]
 pub use crate::corebluetooth::{adapter::Adapter, manager::Manager};
-#[allow(unused_imports)]
 #[cfg(target_os = "windows")]
 pub use crate::winrtble::{adapter::Adapter, manager::Manager};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,13 +78,13 @@ use std::time::Duration;
 
 pub mod api;
 #[cfg(target_os = "linux")]
-pub mod bluez;
+mod bluez;
 mod common;
 #[cfg(any(target_os = "macos", target_os = "ios"))]
-pub mod corebluetooth;
+mod corebluetooth;
 pub mod platform;
 #[cfg(target_os = "windows")]
-pub mod winrtble;
+mod winrtble;
 
 #[derive(Debug, thiserror::Error, Clone)]
 pub enum Error {

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -4,3 +4,11 @@ pub use crate::bluez::{adapter::Adapter, manager::Manager};
 pub use crate::corebluetooth::{adapter::Adapter, manager::Manager};
 #[cfg(target_os = "windows")]
 pub use crate::winrtble::{adapter::Adapter, manager::Manager};
+
+use crate::api::Central;
+use static_assertions::assert_impl_all;
+
+// Ensure that the exported types implement all the expected traits.
+// TODO: Add `Debug`.
+assert_impl_all!(Adapter: Central, Clone, Send, Sized, Sync);
+assert_impl_all!(Manager: Clone, Send, Sized, Sync);

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -1,14 +1,18 @@
 #[cfg(target_os = "linux")]
-pub use crate::bluez::{adapter::Adapter, manager::Manager};
+pub use crate::bluez::{
+    adapter::{peripheral::Peripheral, Adapter},
+    manager::Manager,
+};
 #[cfg(any(target_os = "macos", target_os = "ios"))]
-pub use crate::corebluetooth::{adapter::Adapter, manager::Manager};
+pub use crate::corebluetooth::{adapter::Adapter, manager::Manager, peripheral::Peripheral};
 #[cfg(target_os = "windows")]
-pub use crate::winrtble::{adapter::Adapter, manager::Manager};
+pub use crate::winrtble::{adapter::Adapter, manager::Manager, peripheral::Peripheral};
 
-use crate::api::Central;
+use crate::api::{self, Central};
 use static_assertions::assert_impl_all;
 
 // Ensure that the exported types implement all the expected traits.
 // TODO: Add `Debug`.
 assert_impl_all!(Adapter: Central, Clone, Send, Sized, Sync);
 assert_impl_all!(Manager: Clone, Send, Sized, Sync);
+assert_impl_all!(Peripheral: api::Peripheral, Clone, Send, Sized, Sync);

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -1,0 +1,6 @@
+#[cfg(target_os = "linux")]
+pub use crate::bluez::{adapter::Adapter, manager::Manager};
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+pub use crate::corebluetooth::{adapter::Adapter, manager::Manager};
+#[cfg(target_os = "windows")]
+pub use crate::winrtble::{adapter::Adapter, manager::Manager};

--- a/src/winrtble/adapter.rs
+++ b/src/winrtble/adapter.rs
@@ -25,7 +25,7 @@ pub struct Adapter {
 }
 
 impl Adapter {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         let watcher = Arc::new(Mutex::new(BLEWatcher::new()));
         let manager = AdapterManager::default();
         Adapter { watcher, manager }

--- a/src/winrtble/manager.rs
+++ b/src/winrtble/manager.rs
@@ -12,8 +12,7 @@
 // Copyright (c) 2014 The Rust Project Developers
 
 use super::{adapter::Adapter, bindings};
-#[allow(unused_imports)]
-use crate::{Error, Result};
+use crate::Result;
 
 use bindings::windows::devices::radios::{Radio, RadioKind};
 

--- a/src/winrtble/manager.rs
+++ b/src/winrtble/manager.rs
@@ -16,7 +16,7 @@ use crate::Result;
 
 use bindings::windows::devices::radios::{Radio, RadioKind};
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Manager {}
 
 impl Manager {

--- a/src/winrtble/peripheral.rs
+++ b/src/winrtble/peripheral.rs
@@ -49,7 +49,7 @@ pub struct Peripheral {
 }
 
 impl Peripheral {
-    pub fn new(adapter: AdapterManager<Self>, address: BDAddr) -> Self {
+    pub(crate) fn new(adapter: AdapterManager<Self>, address: BDAddr) -> Self {
         let device = Arc::new(Mutex::new(None));
         let mut properties = PeripheralProperties::default();
         properties.address = address;
@@ -70,7 +70,7 @@ impl Peripheral {
         }
     }
 
-    pub fn update_properties(&self, args: &BluetoothLEAdvertisementReceivedEventArgs) {
+    pub(crate) fn update_properties(&self, args: &BluetoothLEAdvertisementReceivedEventArgs) {
         let mut properties = self.properties.lock().unwrap();
         let advertisement = args.advertisement().unwrap();
 


### PR DESCRIPTION
By re-exporting the platform specific `Manager` and `Adapter` saves the user of the api from doing so and should prevent most api users from "accidentally" making their code platform specific.

By type-aliasing `Adapter `as `ConnectedAdapter` for mac and windows, and adding a no-op `connect` the user doesn't have to care that only linux
has a difference between the two.