### PR TITLE
Expose manufacturer data as HashMap rather than concatenating it all

### DIFF
--- a/examples/lights.rs
+++ b/examples/lights.rs
@@ -1,16 +1,13 @@
 extern crate btleplug;
 extern crate rand;
 
+use btleplug::api::{Central, Peripheral, UUID};
 #[cfg(target_os = "linux")]
 use btleplug::bluez::manager::Manager;
 #[cfg(target_os = "macos")]
 use btleplug::corebluetooth::manager::Manager;
 #[cfg(target_os = "windows")]
 use btleplug::winrtble::manager::Manager;
-use btleplug::{
-    api::{Central, Peripheral, UUID},
-    Error, Result,
-};
 use rand::{thread_rng, Rng};
 use std::thread;
 use std::time::Duration;

--- a/src/api/adapter_manager.rs
+++ b/src/api/adapter_manager.rs
@@ -108,8 +108,8 @@ where
         {
             current_peripheral.properties().local_name = peripheral.properties().local_name;
         }
-        if peripheral.properties().manufacturer_data.is_some()
-            && current_peripheral.properties().manufacturer_data.is_none()
+        if !peripheral.properties().manufacturer_data.is_empty()
+            && current_peripheral.properties().manufacturer_data.is_empty()
         {
             current_peripheral.properties().manufacturer_data =
                 peripheral.properties().manufacturer_data;

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -23,7 +23,7 @@ use crate::{
 use serde::{Deserialize, Serialize};
 use std::sync::mpsc::Receiver;
 use std::{
-    collections::BTreeSet,
+    collections::{BTreeSet, HashMap},
     convert::TryFrom,
     fmt::{self, Debug, Display, Formatter},
     str::FromStr,
@@ -296,8 +296,9 @@ pub struct PeripheralProperties {
     pub local_name: Option<String>,
     /// The transmission power level for the device
     pub tx_power_level: Option<i8>,
-    /// Unstructured data set by the device manufacturer
-    pub manufacturer_data: Option<Vec<u8>>,
+    /// Advertisement data specific to the device manufacturer. The keys of this map are
+    /// 'manufacturer IDs', while the values are arbitrary data.
+    pub manufacturer_data: HashMap<u16, Vec<u8>>,
     /// Number of times we've seen advertising reports for this device
     pub discovery_count: u32,
     /// True if we've discovered the device before

--- a/src/corebluetooth/peripheral.rs
+++ b/src/corebluetooth/peripheral.rs
@@ -26,7 +26,7 @@ use async_std::{
     task,
 };
 use std::{
-    collections::BTreeSet,
+    collections::{BTreeSet, HashMap},
     fmt::{self, Debug, Display, Formatter},
     iter::FromIterator,
     sync::{Arc, Mutex},
@@ -64,7 +64,7 @@ impl Peripheral {
             address_type: AddressType::Random,
             local_name: Some(local_name),
             tx_power_level: None,
-            manufacturer_data: None,
+            manufacturer_data: HashMap::new(),
             discovery_count: 1,
             has_scan_response: true,
         };


### PR DESCRIPTION
It's not very useful for clients to receive all manufacturer data concatenated together, when it has a well-defined structure.

This is a breaking change to the API.