### PR TITLE
Remove unimplemented methods and fix return type of request

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -142,8 +142,6 @@ pub struct ValueNotification {
 }
 
 pub type Callback<T> = Box<dyn Fn(Result<T>) + Send>;
-pub type CommandCallback = Callback<()>;
-pub type RequestCallback = Callback<Vec<u8>>;
 
 pub type NotificationHandler = Box<dyn FnMut(ValueNotification) + Send>;
 
@@ -341,51 +339,17 @@ pub trait Peripheral: Send + Sync + Clone + Debug {
         end: u16,
     ) -> Result<Vec<Characteristic>>;
 
-    /// Sends a command (`write-without-response`) to the characteristic. Takes an optional callback
-    /// that will be notified in case of error or when the command has been successfully acked by the
-    /// device.
-    fn command_async(
-        &self,
-        characteristic: &Characteristic,
-        data: &[u8],
-        handler: Option<CommandCallback>,
-    );
-
     /// Sends a command (write without response) to the characteristic. Synchronously returns a
     /// `Result` with an error set if the command was not accepted by the device.
     fn command(&self, characteristic: &Characteristic, data: &[u8]) -> Result<()>;
-
-    /// Sends a request (write) to the device. Takes an optional callback with either an error if
-    /// the request was not accepted or the response from the device.
-    fn request_async(
-        &self,
-        characteristic: &Characteristic,
-        data: &[u8],
-        handler: Option<RequestCallback>,
-    );
 
     /// Sends a request (write) to the device. Synchronously returns either an error if the request
     /// was not accepted or the response from the device.
     fn request(&self, characteristic: &Characteristic, data: &[u8]) -> Result<Vec<u8>>;
 
-    /// Sends a request (read) to the device. Takes an optional callback with either an error if
-    /// the request was not accepted or the response from the device.
-    fn read_async(&self, characteristic: &Characteristic, handler: Option<RequestCallback>);
-
     /// Sends a request (read) to the device. Synchronously returns either an error if the request
     /// was not accepted or the response from the device.
     fn read(&self, characteristic: &Characteristic) -> Result<Vec<u8>>;
-
-    /// Sends a read-by-type request to device for the range of handles covered by the
-    /// characteristic and for the specified declaration UUID. See
-    /// [here](https://www.bluetooth.com/specifications/gatt/declarations) for valid UUIDs.
-    /// Takes an optional callback that will be called with an error or the device response.
-    fn read_by_type_async(
-        &self,
-        characteristic: &Characteristic,
-        uuid: UUID,
-        handler: Option<RequestCallback>,
-    );
 
     /// Sends a read-by-type request to device for the range of handles covered by the
     /// characteristic and for the specified declaration UUID. See

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -343,9 +343,9 @@ pub trait Peripheral: Send + Sync + Clone + Debug {
     /// `Result` with an error set if the command was not accepted by the device.
     fn command(&self, characteristic: &Characteristic, data: &[u8]) -> Result<()>;
 
-    /// Sends a request (write) to the device. Synchronously returns either an error if the request
-    /// was not accepted or the response from the device.
-    fn request(&self, characteristic: &Characteristic, data: &[u8]) -> Result<Vec<u8>>;
+    /// Sends a request (write) to the characteristic. Synchronously returns a `Result` with an
+    /// error set if the request was not accepted by the device.
+    fn request(&self, characteristic: &Characteristic, data: &[u8]) -> Result<()>;
 
     /// Sends a request (read) to the device. Synchronously returns either an error if the request
     /// was not accepted or the response from the device.

--- a/src/bluez/adapter/peripheral.rs
+++ b/src/bluez/adapter/peripheral.rs
@@ -476,10 +476,8 @@ impl ApiPeripheral for Peripheral {
             .ok_or(Error::NotSupported("write_without_response".to_string()))??)
     }
 
-    fn request(&self, characteristic: &Characteristic, data: &[u8]) -> Result<Vec<u8>> {
-        self.command(characteristic, data)?;
-
-        self.read(characteristic)
+    fn request(&self, characteristic: &Characteristic, data: &[u8]) -> Result<()> {
+        self.command(characteristic, data)
     }
 
     fn read(&self, characteristic: &Characteristic) -> Result<Vec<u8>> {

--- a/src/bluez/adapter/peripheral.rs
+++ b/src/bluez/adapter/peripheral.rs
@@ -24,8 +24,8 @@ use bytes::BufMut;
 use crate::{
     api::{
         AdapterManager, AddressType, BDAddr, CentralEvent, CharPropFlags, Characteristic,
-        CommandCallback, NotificationHandler, Peripheral as ApiPeripheral, PeripheralProperties,
-        RequestCallback, ValueNotification, UUID,
+        NotificationHandler, Peripheral as ApiPeripheral, PeripheralProperties, ValueNotification,
+        UUID,
     },
     bluez::{
         bluez_dbus::device::OrgBluezDevice1, bluez_dbus::device::OrgBluezDevice1Properties,
@@ -468,15 +468,6 @@ impl ApiPeripheral for Peripheral {
             .collect())
     }
 
-    fn command_async(
-        &self,
-        _characteristic: &Characteristic,
-        _data: &[u8],
-        _handler: Option<CommandCallback>,
-    ) {
-        unimplemented!()
-    }
-
     fn command(&self, characteristic: &Characteristic, data: &[u8]) -> Result<()> {
         use crate::bluez::bluez_dbus::gatt_characteristic::OrgBluezGattCharacteristic1;
         Ok(self
@@ -485,23 +476,10 @@ impl ApiPeripheral for Peripheral {
             .ok_or(Error::NotSupported("write_without_response".to_string()))??)
     }
 
-    fn request_async(
-        &self,
-        _characteristic: &Characteristic,
-        _data: &[u8],
-        _handler: Option<RequestCallback>,
-    ) {
-        unimplemented!()
-    }
-
     fn request(&self, characteristic: &Characteristic, data: &[u8]) -> Result<Vec<u8>> {
         self.command(characteristic, data)?;
 
         self.read(characteristic)
-    }
-
-    fn read_async(&self, _characteristic: &Characteristic, _handler: Option<RequestCallback>) {
-        unimplemented!()
     }
 
     fn read(&self, characteristic: &Characteristic) -> Result<Vec<u8>> {
@@ -510,15 +488,6 @@ impl ApiPeripheral for Peripheral {
             .proxy_for(&characteristic)
             .map(|p| p.read_value(HashMap::new()))
             .ok_or(Error::NotSupported("read".to_string()))??)
-    }
-
-    fn read_by_type_async(
-        &self,
-        _characteristic: &Characteristic,
-        _uuid: UUID,
-        _handler: Option<RequestCallback>,
-    ) {
-        unimplemented!()
     }
 
     // Is this looking for a characteristic with a descriptor? or a service with a characteristic?

--- a/src/corebluetooth/peripheral.rs
+++ b/src/corebluetooth/peripheral.rs
@@ -13,9 +13,8 @@ use super::{
 };
 use crate::{
     api::{
-        AdapterManager, AddressType, BDAddr, CentralEvent, Characteristic, CommandCallback,
-        NotificationHandler, Peripheral as ApiPeripheral, PeripheralProperties, RequestCallback,
-        ValueNotification, UUID,
+        AdapterManager, AddressType, BDAddr, CentralEvent, Characteristic, NotificationHandler,
+        Peripheral as ApiPeripheral, PeripheralProperties, ValueNotification, UUID,
     },
     common::util,
     Error, Result,
@@ -214,18 +213,6 @@ impl ApiPeripheral for Peripheral {
         panic!("NOT IMPLEMENTED");
     }
 
-    /// Sends a command (`write-without-response`) to the characteristic. Takes an optional callback
-    /// that will be notified in case of error or when the command has been successfully acked by the
-    /// device.
-    fn command_async(
-        &self,
-        _characteristic: &Characteristic,
-        _data: &[u8],
-        _handler: Option<CommandCallback>,
-    ) {
-        info!("Trying to command!");
-    }
-
     /// Sends a command (write without response) to the characteristic. Synchronously returns a
     /// `Result` with an error set if the command was not accepted by the device.
     fn command(&self, characteristic: &Characteristic, data: &[u8]) -> Result<()> {
@@ -246,16 +233,6 @@ impl ApiPeripheral for Peripheral {
             }
         });
         Ok(())
-    }
-
-    /// Sends a request (write) to the device. Takes an optional callback with either an error if
-    /// the request was not accepted or the response from the device.
-    fn request_async(
-        &self,
-        _characteristic: &Characteristic,
-        _data: &[u8],
-        _handler: Option<RequestCallback>,
-    ) {
     }
 
     /// Sends a request (write) to the device. Synchronously returns either an error if the request
@@ -286,18 +263,6 @@ impl ApiPeripheral for Peripheral {
             }
         });
         Ok(result)
-    }
-
-    /// Sends a read-by-type request to device for the range of handles covered by the
-    /// characteristic and for the specified declaration UUID. See
-    /// [here](https://www.bluetooth.com/specifications/gatt/declarations) for valid UUIDs.
-    /// Takes an optional callback that will be called with an error or the device response.
-    fn read_by_type_async(
-        &self,
-        _characteristic: &Characteristic,
-        _uuid: UUID,
-        _handler: Option<RequestCallback>,
-    ) {
     }
 
     /// Sends a read-by-type request to device for the range of handles covered by the
@@ -357,8 +322,6 @@ impl ApiPeripheral for Peripheral {
         let mut list = self.notification_handlers.lock().unwrap();
         list.push(handler);
     }
-
-    fn read_async(&self, _characteristic: &Characteristic, _handler: Option<RequestCallback>) {}
 
     fn read(&self, characteristic: &Characteristic) -> Result<Vec<u8>> {
         info!("Trying read!");

--- a/src/corebluetooth/peripheral.rs
+++ b/src/corebluetooth/peripheral.rs
@@ -237,14 +237,7 @@ impl ApiPeripheral for Peripheral {
 
     /// Sends a request (write) to the device. Synchronously returns either an error if the request
     /// was not accepted or the response from the device.
-    fn request(&self, characteristic: &Characteristic, data: &[u8]) -> Result<Vec<u8>> {
-        // Not sure what to return, since a write will not respond with the data. So, erm, let's
-        // just return what was passed in.
-        let mut result = Vec::<u8>::new();
-        for i in 0..data.len() {
-            result.push(data[i]);
-        }
-
+    fn request(&self, characteristic: &Characteristic, data: &[u8]) -> Result<()> {
         task::block_on(async {
             let fut = CoreBluetoothReplyFuture::default();
             self.message_sender
@@ -262,7 +255,7 @@ impl ApiPeripheral for Peripheral {
                 }
             }
         });
-        Ok(result)
+        Ok(())
     }
 
     /// Sends a read-by-type request to device for the range of handles covered by the

--- a/src/winrtble/peripheral.rs
+++ b/src/winrtble/peripheral.rs
@@ -14,9 +14,8 @@
 use super::{bindings, ble::characteristic::BLECharacteristic, ble::device::BLEDevice, utils};
 use crate::{
     api::{
-        AdapterManager, AddressType, BDAddr, CentralEvent, Characteristic, CommandCallback,
-        NotificationHandler, Peripheral as ApiPeripheral, PeripheralProperties, RequestCallback,
-        ValueNotification, UUID,
+        AdapterManager, AddressType, BDAddr, CentralEvent, Characteristic, NotificationHandler,
+        Peripheral as ApiPeripheral, PeripheralProperties, ValueNotification, UUID,
     },
     common::util,
     Error, Result,
@@ -241,17 +240,6 @@ impl ApiPeripheral for Peripheral {
         Ok(Vec::new())
     }
 
-    /// Sends a command (`write-without-response`) to the characteristic. Takes an optional callback
-    /// that will be notified in case of error or when the command has been successfully acked by the
-    /// device.
-    fn command_async(
-        &self,
-        _characteristic: &Characteristic,
-        _data: &[u8],
-        _handler: Option<CommandCallback>,
-    ) {
-    }
-
     /// Sends a command (write without response) to the characteristic. Synchronously returns a
     /// `Result` with an error set if the command was not accepted by the device.
     fn command(&self, _characteristic: &Characteristic, _data: &[u8]) -> Result<()> {
@@ -262,32 +250,10 @@ impl ApiPeripheral for Peripheral {
         }
     }
 
-    /// Sends a request (write) to the device. Takes an optional callback with either an error if
-    /// the request was not accepted or the response from the device.
-    fn request_async(
-        &self,
-        _characteristic: &Characteristic,
-        _data: &[u8],
-        _handler: Option<RequestCallback>,
-    ) {
-    }
-
     /// Sends a request (write) to the device. Synchronously returns either an error if the request
     /// was not accepted or the response from the device.
     fn request(&self, _characteristic: &Characteristic, _data: &[u8]) -> Result<Vec<u8>> {
         Ok(Vec::new())
-    }
-
-    /// Sends a read-by-type request to device for the range of handles covered by the
-    /// characteristic and for the specified declaration UUID. See
-    /// [here](https://www.bluetooth.com/specifications/gatt/declarations) for valid UUIDs.
-    /// Takes an optional callback that will be called with an error or the device response.
-    fn read_by_type_async(
-        &self,
-        _characteristic: &Characteristic,
-        _uuid: UUID,
-        _handler: Option<RequestCallback>,
-    ) {
     }
 
     /// Sends a read-by-type request to device for the range of handles covered by the
@@ -340,8 +306,6 @@ impl ApiPeripheral for Peripheral {
         let mut list = self.notification_handlers.lock().unwrap();
         list.push(handler);
     }
-
-    fn read_async(&self, _characteristic: &Characteristic, _handler: Option<RequestCallback>) {}
 
     fn read(&self, characteristic: &Characteristic) -> Result<Vec<u8>> {
         if let Some(ble_characteristic) = self.ble_characteristics.get(&characteristic.uuid) {

--- a/src/winrtble/peripheral.rs
+++ b/src/winrtble/peripheral.rs
@@ -242,18 +242,18 @@ impl ApiPeripheral for Peripheral {
 
     /// Sends a command (write without response) to the characteristic. Synchronously returns a
     /// `Result` with an error set if the command was not accepted by the device.
-    fn command(&self, _characteristic: &Characteristic, _data: &[u8]) -> Result<()> {
-        if let Some(ble_characteristic) = self.ble_characteristics.get(&_characteristic.uuid) {
-            ble_characteristic.write_value(_data)
+    fn command(&self, characteristic: &Characteristic, data: &[u8]) -> Result<()> {
+        if let Some(ble_characteristic) = self.ble_characteristics.get(&characteristic.uuid) {
+            ble_characteristic.write_value(data)
         } else {
             Err(Error::NotSupported("command".into()))
         }
     }
 
-    /// Sends a request (write) to the device. Synchronously returns either an error if the request
-    /// was not accepted or the response from the device.
-    fn request(&self, _characteristic: &Characteristic, _data: &[u8]) -> Result<Vec<u8>> {
-        Ok(Vec::new())
+    /// Sends a request (write) to the device.  Synchronously returns a `Result` with an error set
+    /// if the request was not accepted by the device.
+    fn request(&self, characteristic: &Characteristic, data: &[u8]) -> Result<()> {
+        self.command(characteristic, data)
     }
 
     /// Sends a read-by-type request to device for the range of handles covered by the

--- a/src/winrtble/peripheral.rs
+++ b/src/winrtble/peripheral.rs
@@ -246,7 +246,7 @@ impl ApiPeripheral for Peripheral {
         if let Some(ble_characteristic) = self.ble_characteristics.get(&_characteristic.uuid) {
             ble_characteristic.write_value(_data)
         } else {
-            Err(Error::NotSupported("read_by_type".into()))
+            Err(Error::NotSupported("command".into()))
         }
     }
 


### PR DESCRIPTION
This removes `command_async`, `request_async`, `read_async` and `read_by_type_async`, which were not implemented on any platform. This is theoretically a breaking change, but any user of them is already broken because none of them actually did what they claimed to.

I've also removed the return value of `request`, because it seems to have originated from a misunderstanding of the GATT protocol. The device doesn't send a value back, only a confirmation that the write succeeded. On platforms where this was implemented it was just returning the same value which was written, which is not very useful.

We could consider going a step further and merging `request` and `command` into a single `write` method, as it is unlikely to matter to a user of the library whether it is really a write or a write-without-response. Any given characteristic will usually only support one or the other. The only platform which allows a distinction to be made between the two is Mac OS.

Fixes #104.