### PR TITLE
Replace request and command with a single write method.

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ use std::thread;
 use std::time::Duration;
 use rand::{Rng, thread_rng};
 use rumble::bluez::manager::Manager;
-use rumble::api::{Central, Peripheral, WriteKind, UUID};
+use rumble::api::{Central, Peripheral, WriteType, UUID};
 
 pub fn main() {
     let manager = Manager::new().unwrap();
@@ -236,7 +236,7 @@ pub fn main() {
     let mut rng = thread_rng();
     for _ in 0..20 {
         let color_cmd = vec![0x56, rng.gen(), rng.gen(), rng.gen(), 0x00, 0xF0, 0xAA];
-        light.write(&cmd_char, &color_cmd, WriteKind::WithoutResponse).unwrap();
+        light.write(&cmd_char, &color_cmd, WriteType::WithoutResponse).unwrap();
         thread::sleep(Duration::from_millis(200));
     }
 }

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ use std::thread;
 use std::time::Duration;
 use rand::{Rng, thread_rng};
 use rumble::bluez::manager::Manager;
-use rumble::api::{UUID, Central, Peripheral};
+use rumble::api::{Central, Peripheral, WriteKind, UUID};
 
 pub fn main() {
     let manager = Manager::new().unwrap();
@@ -236,7 +236,7 @@ pub fn main() {
     let mut rng = thread_rng();
     for _ in 0..20 {
         let color_cmd = vec![0x56, rng.gen(), rng.gen(), rng.gen(), 0x00, 0xF0, 0xAA];
-        light.command(&cmd_char, &color_cmd).unwrap();
+        light.write(&cmd_char, &color_cmd, WriteKind::WithoutResponse).unwrap();
         thread::sleep(Duration::from_millis(200));
     }
 }

--- a/examples/lights.rs
+++ b/examples/lights.rs
@@ -1,7 +1,7 @@
 extern crate btleplug;
 extern crate rand;
 
-use btleplug::api::{Central, Peripheral, WriteKind, UUID};
+use btleplug::api::{Central, Peripheral, WriteType, UUID};
 #[cfg(target_os = "linux")]
 use btleplug::bluez::manager::Manager;
 #[cfg(target_os = "macos")]
@@ -59,7 +59,7 @@ pub fn main() {
     for _ in 0..20 {
         let color_cmd = vec![0x56, rng.gen(), rng.gen(), rng.gen(), 0x00, 0xF0, 0xAA];
         light
-            .write(&cmd_char, &color_cmd, WriteKind::WithoutResponse)
+            .write(&cmd_char, &color_cmd, WriteType::WithoutResponse)
             .unwrap();
         thread::sleep(Duration::from_millis(200));
     }

--- a/examples/lights.rs
+++ b/examples/lights.rs
@@ -1,7 +1,7 @@
 extern crate btleplug;
 extern crate rand;
 
-use btleplug::api::{Central, Peripheral, UUID};
+use btleplug::api::{Central, Peripheral, WriteKind, UUID};
 #[cfg(target_os = "linux")]
 use btleplug::bluez::manager::Manager;
 #[cfg(target_os = "macos")]
@@ -58,7 +58,9 @@ pub fn main() {
     let mut rng = thread_rng();
     for _ in 0..20 {
         let color_cmd = vec![0x56, rng.gen(), rng.gen(), rng.gen(), 0x00, 0xF0, 0xAA];
-        light.command(&cmd_char, &color_cmd).unwrap();
+        light
+            .write(&cmd_char, &color_cmd, WriteKind::WithoutResponse)
+            .unwrap();
         thread::sleep(Duration::from_millis(200));
     }
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -305,7 +305,7 @@ pub struct PeripheralProperties {
 
 /// The type of write operation to use.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum WriteKind {
+pub enum WriteType {
     /// A write operation where the device is expected to respond with a confirmation or error. Also
     /// known as a request.
     WithResponse,
@@ -344,7 +344,12 @@ pub trait Peripheral: Send + Sync + Clone + Debug {
 
     /// Write some data to the characteristic. Returns an error if the write couldn't be send or (in
     /// the case of a write-with-response) if the device returns an error.
-    fn write(&self, characteristic: &Characteristic, data: &[u8], kind: WriteKind) -> Result<()>;
+    fn write(
+        &self,
+        characteristic: &Characteristic,
+        data: &[u8],
+        write_type: WriteType,
+    ) -> Result<()>;
 
     /// Sends a request (read) to the device. Synchronously returns either an error if the request
     /// was not accepted or the response from the device.

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -303,6 +303,16 @@ pub struct PeripheralProperties {
     pub has_scan_response: bool,
 }
 
+/// The type of write operation to use.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum WriteKind {
+    /// A write operation where the device is expected to respond with a confirmation or error. Also
+    /// known as a request.
+    WithResponse,
+    /// A write-without-response, also known as a command.
+    WithoutResponse,
+}
+
 /// Peripheral is the device that you would like to communicate with (the "server" of BLE). This
 /// struct contains both the current state of the device (its properties, characteristics, etc.)
 /// as well as functions for communication.
@@ -332,13 +342,9 @@ pub trait Peripheral: Send + Sync + Clone + Debug {
     /// Discovers all characteristics for the device. This is a synchronous operation.
     fn discover_characteristics(&self) -> Result<Vec<Characteristic>>;
 
-    /// Sends a command (write without response) to the characteristic. Synchronously returns a
-    /// `Result` with an error set if the command was not accepted by the device.
-    fn command(&self, characteristic: &Characteristic, data: &[u8]) -> Result<()>;
-
-    /// Sends a request (write) to the characteristic. Synchronously returns a `Result` with an
-    /// error set if the request was not accepted by the device.
-    fn request(&self, characteristic: &Characteristic, data: &[u8]) -> Result<()>;
+    /// Write some data to the characteristic. Returns an error if the write couldn't be send or (in
+    /// the case of a write-with-response) if the device returns an error.
+    fn write(&self, characteristic: &Characteristic, data: &[u8], kind: WriteKind) -> Result<()>;
 
     /// Sends a request (read) to the device. Synchronously returns either an error if the request
     /// was not accepted or the response from the device.

--- a/src/bluez/adapter/peripheral.rs
+++ b/src/bluez/adapter/peripheral.rs
@@ -23,7 +23,7 @@ use crate::{
     api::{
         AdapterManager, AddressType, BDAddr, CentralEvent, CharPropFlags, Characteristic,
         NotificationHandler, Peripheral as ApiPeripheral, PeripheralProperties, ValueNotification,
-        WriteKind, UUID,
+        WriteType, UUID,
     },
     bluez::{
         bluez_dbus::device::OrgBluezDevice1, bluez_dbus::device::OrgBluezDevice1Properties,
@@ -460,14 +460,19 @@ impl ApiPeripheral for Peripheral {
             .collect())
     }
 
-    fn write(&self, characteristic: &Characteristic, data: &[u8], kind: WriteKind) -> Result<()> {
+    fn write(
+        &self,
+        characteristic: &Characteristic,
+        data: &[u8],
+        write_type: WriteType,
+    ) -> Result<()> {
         let mut options: PropMap = HashMap::new();
         options.insert(
             "type".to_string(),
             Variant(Box::new(
-                match kind {
-                    WriteKind::WithResponse => "request",
-                    WriteKind::WithoutResponse => "command",
+                match write_type {
+                    WriteType::WithResponse => "request",
+                    WriteType::WithoutResponse => "command",
                 }
                 .to_string(),
             )),

--- a/src/corebluetooth/internal.rs
+++ b/src/corebluetooth/internal.rs
@@ -14,7 +14,7 @@ use super::{
     future::{BtlePlugFuture, BtlePlugFutureStateShared},
     utils::{CoreBluetoothUtils, NSStringUtils},
 };
-use crate::api::{CharPropFlags, Characteristic, WriteKind, UUID};
+use crate::api::{CharPropFlags, Characteristic, WriteType, UUID};
 use async_std::{
     channel::{self, Receiver, Sender},
     task,
@@ -248,7 +248,7 @@ pub enum CoreBluetoothMessage {
         Uuid,
         Uuid,
         Vec<u8>,
-        WriteKind,
+        WriteType,
         CoreBluetoothReplyStateShared,
     ),
     // device uuid, characteristic uuid, future
@@ -448,7 +448,7 @@ impl CoreBluetoothInternal {
         peripheral_uuid: Uuid,
         characteristic_uuid: Uuid,
         data: Vec<u8>,
-        kind: WriteKind,
+        kind: WriteType,
         fut: CoreBluetoothReplyStateShared,
     ) {
         if let Some(p) = self.peripherals.get_mut(&peripheral_uuid) {
@@ -459,8 +459,8 @@ impl CoreBluetoothInternal {
                     ns::data(data.as_ptr(), data.len() as c_uint),
                     *c.characteristic,
                     match kind {
-                        WriteKind::WithResponse => 0,
-                        WriteKind::WithoutResponse => 1,
+                        WriteType::WithResponse => 0,
+                        WriteType::WithoutResponse => 1,
                     },
                 );
                 c.write_future_state.push_front(fut);

--- a/src/corebluetooth/peripheral.rs
+++ b/src/corebluetooth/peripheral.rs
@@ -14,7 +14,7 @@ use super::{
 use crate::{
     api::{
         AdapterManager, AddressType, BDAddr, CentralEvent, Characteristic, NotificationHandler,
-        Peripheral as ApiPeripheral, PeripheralProperties, ValueNotification, WriteKind, UUID,
+        Peripheral as ApiPeripheral, PeripheralProperties, ValueNotification, WriteType, UUID,
     },
     common::util,
     Error, Result,
@@ -205,7 +205,12 @@ impl ApiPeripheral for Peripheral {
 
     /// Write some data to the characteristic. Returns an error if the write couldn't be send or (in
     /// the case of a write-with-response) if the device returns an error.
-    fn write(&self, characteristic: &Characteristic, data: &[u8], kind: WriteKind) -> Result<()> {
+    fn write(
+        &self,
+        characteristic: &Characteristic,
+        data: &[u8],
+        write_type: WriteType,
+    ) -> Result<()> {
         task::block_on(async {
             let fut = CoreBluetoothReplyFuture::default();
             self.message_sender
@@ -213,7 +218,7 @@ impl ApiPeripheral for Peripheral {
                     self.uuid,
                     get_apple_uuid(characteristic.uuid),
                     Vec::from(data),
-                    kind,
+                    write_type,
                     fut.get_state_clone(),
                 ))
                 .await?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@
 //! use btleplug::winrtble::{adapter::Adapter, manager::Manager};
 //! #[cfg(target_os = "macos")]
 //! use btleplug::corebluetooth::{adapter::Adapter, manager::Manager};
-//! use btleplug::api::{UUID, Central, Peripheral};
+//! use btleplug::api::{Central, Peripheral, WriteKind, UUID};
 //!
 //! // adapter retreival works differently depending on your platform right now.
 //! // API needs to be aligned.
@@ -69,7 +69,7 @@
 //!     let mut rng = thread_rng();
 //!     for _ in 0..20 {
 //!         let color_cmd = vec![0x56, rng.gen(), rng.gen(), rng.gen(), 0x00, 0xF0, 0xAA];
-//!         light.command(&cmd_char, &color_cmd).unwrap();
+//!         light.write(&cmd_char, &color_cmd, WriteKind::WithoutResponse).unwrap();
 //!         thread::sleep(Duration::from_millis(200));
 //!     }
 //! }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@
 //! use btleplug::winrtble::{adapter::Adapter, manager::Manager};
 //! #[cfg(target_os = "macos")]
 //! use btleplug::corebluetooth::{adapter::Adapter, manager::Manager};
-//! use btleplug::api::{Central, Peripheral, WriteKind, UUID};
+//! use btleplug::api::{Central, Peripheral, WriteType, UUID};
 //!
 //! // adapter retreival works differently depending on your platform right now.
 //! // API needs to be aligned.
@@ -69,7 +69,7 @@
 //!     let mut rng = thread_rng();
 //!     for _ in 0..20 {
 //!         let color_cmd = vec![0x56, rng.gen(), rng.gen(), rng.gen(), 0x00, 0xF0, 0xAA];
-//!         light.write(&cmd_char, &color_cmd, WriteKind::WithoutResponse).unwrap();
+//!         light.write(&cmd_char, &color_cmd, WriteType::WithoutResponse).unwrap();
 //!         thread::sleep(Duration::from_millis(200));
 //!     }
 //! }

--- a/src/winrtble/ble/characteristic.rs
+++ b/src/winrtble/ble/characteristic.rs
@@ -12,16 +12,25 @@
 // Copyright (c) 2014 The Rust Project Developers
 
 use super::super::bindings;
-use crate::{Error, Result};
+use crate::{Error, Result, api::WriteType};
 
 use bindings::windows::devices::bluetooth::generic_attribute_profile::{
     GattCharacteristic, GattClientCharacteristicConfigurationDescriptorValue,
-    GattCommunicationStatus, GattValueChangedEventArgs,
+    GattCommunicationStatus, GattValueChangedEventArgs, GattWriteOption,
 };
 use bindings::windows::foundation::{EventRegistrationToken, TypedEventHandler};
 use bindings::windows::storage::streams::{DataReader, DataWriter};
 
 pub type NotifiyEventHandler = Box<dyn Fn(Vec<u8>) + Send>;
+
+impl Into<GattWriteOption> for WriteType {
+    fn into(self) -> GattWriteOption {
+        match self {
+            WriteType::WithoutResponse => GattWriteOption::WriteWithoutResponse,
+            WriteType::WithResponse => GattWriteOption::WriteWithResponse,
+        }
+    }
+}
 
 pub struct BLECharacteristic {
     characteristic: GattCharacteristic,
@@ -39,13 +48,13 @@ impl BLECharacteristic {
         }
     }
 
-    pub fn write_value(&self, data: &[u8]) -> Result<()> {
+    pub fn write_value(&self, data: &[u8], write_type: WriteType) -> Result<()> {
         let writer = DataWriter::new().unwrap();
         writer.write_bytes(data).unwrap();
         let buffer = writer.detach_buffer().unwrap();
         let result = self
             .characteristic
-            .write_value_async(&buffer)
+            .write_value_with_option_async(&buffer, write_type.into())
             .unwrap()
             .get()
             .unwrap();

--- a/src/winrtble/peripheral.rs
+++ b/src/winrtble/peripheral.rs
@@ -236,9 +236,8 @@ impl ApiPeripheral for Peripheral {
         data: &[u8],
         write_type: WriteType,
     ) -> Result<()> {
-        // TODO: Use the WriteType.
         if let Some(ble_characteristic) = self.ble_characteristics.get(&characteristic.uuid) {
-            ble_characteristic.write_value(data)
+            ble_characteristic.write_value(data, write_type)
         } else {
             Err(Error::NotSupported("write".into()))
         }

--- a/src/winrtble/peripheral.rs
+++ b/src/winrtble/peripheral.rs
@@ -15,7 +15,7 @@ use super::{bindings, ble::characteristic::BLECharacteristic, ble::device::BLEDe
 use crate::{
     api::{
         AdapterManager, AddressType, BDAddr, CentralEvent, Characteristic, NotificationHandler,
-        Peripheral as ApiPeripheral, PeripheralProperties, ValueNotification, WriteKind, UUID,
+        Peripheral as ApiPeripheral, PeripheralProperties, ValueNotification, WriteType, UUID,
     },
     common::util,
     Error, Result,
@@ -230,8 +230,13 @@ impl ApiPeripheral for Peripheral {
 
     /// Write some data to the characteristic. Returns an error if the write couldn't be send or (in
     /// the case of a write-with-response) if the device returns an error.
-    fn write(&self, characteristic: &Characteristic, data: &[u8], kind: WriteKind) -> Result<()> {
-        // TODO: Use the WriteKind.
+    fn write(
+        &self,
+        characteristic: &Characteristic,
+        data: &[u8],
+        write_type: WriteType,
+    ) -> Result<()> {
+        // TODO: Use the WriteType.
         if let Some(ble_characteristic) = self.ble_characteristics.get(&characteristic.uuid) {
             ble_characteristic.write_value(data)
         } else {

--- a/src/winrtble/peripheral.rs
+++ b/src/winrtble/peripheral.rs
@@ -15,7 +15,7 @@ use super::{bindings, ble::characteristic::BLECharacteristic, ble::device::BLEDe
 use crate::{
     api::{
         AdapterManager, AddressType, BDAddr, CentralEvent, Characteristic, NotificationHandler,
-        Peripheral as ApiPeripheral, PeripheralProperties, ValueNotification, UUID,
+        Peripheral as ApiPeripheral, PeripheralProperties, ValueNotification, WriteKind, UUID,
     },
     common::util,
     Error, Result,
@@ -228,20 +228,15 @@ impl ApiPeripheral for Peripheral {
         Err(Error::NotConnected)
     }
 
-    /// Sends a command (write without response) to the characteristic. Synchronously returns a
-    /// `Result` with an error set if the command was not accepted by the device.
-    fn command(&self, characteristic: &Characteristic, data: &[u8]) -> Result<()> {
+    /// Write some data to the characteristic. Returns an error if the write couldn't be send or (in
+    /// the case of a write-with-response) if the device returns an error.
+    fn write(&self, characteristic: &Characteristic, data: &[u8], kind: WriteKind) -> Result<()> {
+        // TODO: Use the WriteKind.
         if let Some(ble_characteristic) = self.ble_characteristics.get(&characteristic.uuid) {
             ble_characteristic.write_value(data)
         } else {
-            Err(Error::NotSupported("command".into()))
+            Err(Error::NotSupported("write".into()))
         }
-    }
-
-    /// Sends a request (write) to the device.  Synchronously returns a `Result` with an error set
-    /// if the request was not accepted by the device.
-    fn request(&self, characteristic: &Characteristic, data: &[u8]) -> Result<()> {
-        self.command(characteristic, data)
     }
 
     /// Sends a read-by-type request to device for the range of handles covered by the


### PR DESCRIPTION
This is hopefully easier to understand, and more similar to other GATT APIs.

It appears that the write types were backwards on Mac OS before, so this also fixes that.

I don't have a Windows machine to build on, so I haven't been able to implement this on Windows.

Fixes #111.