### PR TITLE
Clean up corebluetooth module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ enum_primitive = "0.1.1"
 bitflags = "1.2.1"
 thiserror = "1.0.23"
 backtrace = "0.3"
-async-std = "1.9.0"
 uuid = "0.8.2"
 serde = { version = "1.0.123", features = ["derive"], default-features = false, optional = true }
 dashmap = "4.0.2"
@@ -44,10 +43,12 @@ winrt = "0.7.2"
 dbus = "0.9.1"
 
 [target.'cfg(target_os = "macos")'.dependencies]
+async-std = "1.9.0"
 objc = "0.2.7"
 cocoa = "0.24.0"
 
 [target.'cfg(target_os = "ios")'.dependencies]
+async-std = "1.9.0"
 objc = "0.2.7"
 cocoa = "0.24.0"
 

--- a/src/api/adapter_manager.rs
+++ b/src/api/adapter_manager.rs
@@ -56,7 +56,6 @@ where
     }
 
     pub fn emit(&self, event: CentralEvent) {
-        //debug!("emitted {:?}", event);
         match event {
             CentralEvent::DeviceDisconnected(addr) => {
                 self.peripherals.remove(&addr);

--- a/src/corebluetooth/adapter.rs
+++ b/src/corebluetooth/adapter.rs
@@ -89,17 +89,19 @@ impl Central<Peripheral> for Adapter {
     fn start_scan(&self) -> Result<()> {
         info!("Starting CoreBluetooth Scan");
         task::block_on(async {
-            self.sender.send(CoreBluetoothMessage::StartScanning).await;
-        });
-        Ok(())
+            self.sender
+                .send(CoreBluetoothMessage::StartScanning)
+                .await?;
+            Ok(())
+        })
     }
 
     fn stop_scan(&self) -> Result<()> {
         info!("Stopping CoreBluetooth Scan");
         task::block_on(async {
-            self.sender.send(CoreBluetoothMessage::StopScanning).await;
-        });
-        Ok(())
+            self.sender.send(CoreBluetoothMessage::StopScanning).await?;
+            Ok(())
+        })
     }
 
     fn peripherals(&self) -> Vec<Peripheral> {

--- a/src/corebluetooth/adapter.rs
+++ b/src/corebluetooth/adapter.rs
@@ -10,7 +10,7 @@ use async_std::{
 use std::convert::TryInto;
 use std::sync::mpsc::Receiver;
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Adapter {
     manager: AdapterManager<Peripheral>,
     sender: Sender<CoreBluetoothMessage>,

--- a/src/corebluetooth/central_delegate.rs
+++ b/src/corebluetooth/central_delegate.rs
@@ -240,7 +240,9 @@ pub mod CentralDelegate {
     extern "C" fn send_delegate_event(delegate: &mut Object, event: CentralDelegateEvent) {
         let sender = delegate_get_sender_clone(delegate);
         task::block_on(async {
-            sender.send(event).await;
+            if let Err(e) = sender.send(event).await {
+                error!("Error sending delegate event: {}", e);
+            }
         });
     }
 

--- a/src/corebluetooth/central_delegate.rs
+++ b/src/corebluetooth/central_delegate.rs
@@ -20,7 +20,14 @@ use async_std::{
     channel::{Receiver, Sender},
     task,
 };
-use std::{collections::HashMap, slice, str::FromStr, sync::Once};
+use std::{
+    collections::HashMap,
+    fmt::{self, Debug, Formatter},
+    ops::Deref,
+    slice,
+    str::FromStr,
+    sync::Once,
+};
 
 use objc::{
     declare::ClassDecl,
@@ -54,6 +61,55 @@ pub enum CentralDelegateEvent {
     CharacteristicWritten(Uuid, Uuid),
     // TODO Deal with descriptors at some point, but not a huge worry at the moment.
     // DiscoveredDescriptors(String, )
+}
+
+impl Debug for CentralDelegateEvent {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        match self {
+            CentralDelegateEvent::DidUpdateState => f.debug_tuple("DidUpdateState").finish(),
+            CentralDelegateEvent::DiscoveredPeripheral(p) => f
+                .debug_tuple("CentralDelegateEvent")
+                .field(p.deref())
+                .finish(),
+            CentralDelegateEvent::DiscoveredServices(uuid, services) => f
+                .debug_tuple("DiscoveredServices")
+                .field(uuid)
+                .field(&services.keys().collect::<Vec<_>>())
+                .finish(),
+            CentralDelegateEvent::DiscoveredCharacteristics(uuid, characteristics) => f
+                .debug_tuple("DiscoveredCharacteristics")
+                .field(uuid)
+                .field(&characteristics.keys().collect::<Vec<_>>())
+                .finish(),
+            CentralDelegateEvent::ConnectedDevice(uuid) => {
+                f.debug_tuple("ConnectedDevice").field(uuid).finish()
+            }
+            CentralDelegateEvent::DisconnectedDevice(uuid) => {
+                f.debug_tuple("DisconnectedDevice").field(uuid).finish()
+            }
+            CentralDelegateEvent::CharacteristicSubscribed(uuid1, uuid2) => f
+                .debug_tuple("CharacteristicSubscribed")
+                .field(uuid1)
+                .field(uuid2)
+                .finish(),
+            CentralDelegateEvent::CharacteristicUnsubscribed(uuid1, uuid2) => f
+                .debug_tuple("CharacteristicUnsubscribed")
+                .field(uuid1)
+                .field(uuid2)
+                .finish(),
+            CentralDelegateEvent::CharacteristicNotified(uuid1, uuid2, vec) => f
+                .debug_tuple("CharacteristicNotified")
+                .field(uuid1)
+                .field(uuid2)
+                .field(vec)
+                .finish(),
+            CentralDelegateEvent::CharacteristicWritten(uuid1, uuid2) => f
+                .debug_tuple("CharacteristicWritten")
+                .field(uuid1)
+                .field(uuid2)
+                .finish(),
+        }
+    }
 }
 
 pub mod CentralDelegate {

--- a/src/corebluetooth/central_delegate.rs
+++ b/src/corebluetooth/central_delegate.rs
@@ -229,7 +229,7 @@ pub mod CentralDelegate {
     //
     ////////////////////////////////////////////////////////////////
 
-    extern "C" fn delegate_get_sender_clone(delegate: &mut Object) -> Sender<CentralDelegateEvent> {
+    fn delegate_get_sender_clone(delegate: &mut Object) -> Sender<CentralDelegateEvent> {
         unsafe {
             (*(*(&mut *delegate).get_ivar::<*mut c_void>(DELEGATE_SENDER_IVAR)
                 as *mut Sender<CentralDelegateEvent>))
@@ -237,7 +237,7 @@ pub mod CentralDelegate {
         }
     }
 
-    extern "C" fn send_delegate_event(delegate: &mut Object, event: CentralDelegateEvent) {
+    fn send_delegate_event(delegate: &mut Object, event: CentralDelegateEvent) {
         let sender = delegate_get_sender_clone(delegate);
         task::block_on(async {
             if let Err(e) = sender.send(event).await {
@@ -267,7 +267,7 @@ pub mod CentralDelegate {
         delegate
     }
 
-    extern "C" fn get_characteristic_value(characteristic: *mut Object) -> Vec<u8> {
+    fn get_characteristic_value(characteristic: *mut Object) -> Vec<u8> {
         info!("Getting data!");
         let value = cb::characteristic_value(characteristic);
         let length = ns::data_length(value);

--- a/src/corebluetooth/internal.rs
+++ b/src/corebluetooth/internal.rs
@@ -263,7 +263,7 @@ pub enum CoreBluetoothEvent {
     AdapterConnected,
     AdapterError,
     // name, identifier, event receiver, message sender
-    DeviceDiscovered(Uuid, String, Receiver<CBPeripheralEvent>),
+    DeviceDiscovered(Uuid, Option<String>, Receiver<CBPeripheralEvent>),
     DeviceUpdated(Uuid, String),
     // identifier
     DeviceLost(Uuid),
@@ -308,9 +308,9 @@ impl CoreBluetoothInternal {
     fn on_discovered_peripheral(&mut self, peripheral: StrongPtr) {
         let uuid_nsstring = ns::uuid_uuidstring(cb::peer_identifier(*peripheral));
         let uuid = Uuid::from_str(&NSStringUtils::string_to_string(uuid_nsstring)).unwrap();
-        let name = NSStringUtils::string_to_string(cb::peripheral_name(*peripheral));
+        let name = NSStringUtils::string_to_maybe_string(cb::peripheral_name(*peripheral));
         if self.peripherals.contains_key(&uuid) {
-            if name != String::from("nil") {
+            if let Some(name) = name {
                 self.dispatch_event(CoreBluetoothEvent::DeviceUpdated(uuid, name));
             }
         } else {

--- a/src/corebluetooth/internal.rs
+++ b/src/corebluetooth/internal.rs
@@ -351,7 +351,7 @@ impl CoreBluetoothInternal {
         }
     }
 
-    fn on_peripheral_connect(&mut self, peripheral_uuid: Uuid) {
+    fn on_peripheral_connect(&mut self, _peripheral_uuid: Uuid) {
         // Don't actually do anything here. The peripheral will fire the future
         // itself when it receives all of its service/characteristic info.
     }
@@ -592,7 +592,7 @@ impl CoreBluetoothInternal {
                         info!("got connectdevice msg!");
                         self.connect_peripheral(peripheral_uuid, fut);
                     }
-                    CoreBluetoothMessage::DisconnectDevice(peripheral_uuid, fut) => {}
+                    CoreBluetoothMessage::DisconnectDevice(_peripheral_uuid, _fut) => {}
                     CoreBluetoothMessage::ReadValue(peripheral_uuid, char_uuid, fut) => {
                         self.read_value(peripheral_uuid, char_uuid, fut)
                     }

--- a/src/corebluetooth/internal.rs
+++ b/src/corebluetooth/internal.rs
@@ -26,6 +26,8 @@ use objc::{
 };
 use std::{
     collections::{BTreeSet, HashMap, VecDeque},
+    fmt::{self, Debug, Formatter},
+    ops::Deref,
     os::raw::c_uint,
     str::FromStr,
     thread,
@@ -40,6 +42,20 @@ struct CBCharacteristic {
     pub write_future_state: VecDeque<CoreBluetoothReplyStateShared>,
     pub subscribe_future_state: VecDeque<CoreBluetoothReplyStateShared>,
     pub unsubscribe_future_state: VecDeque<CoreBluetoothReplyStateShared>,
+}
+
+impl Debug for CBCharacteristic {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        f.debug_struct("CBCharacteristic")
+            .field("characteristic", self.characteristic.deref())
+            .field("uuid", &self.uuid)
+            .field("properties", &self.properties)
+            .field("read_future_state", &self.read_future_state)
+            .field("write_future_state", &self.write_future_state)
+            .field("subscribe_future_state", &self.subscribe_future_state)
+            .field("unsubscribe_future_state", &self.unsubscribe_future_state)
+            .finish()
+    }
 }
 
 impl CBCharacteristic {
@@ -88,6 +104,7 @@ impl CBCharacteristic {
     }
 }
 
+#[derive(Debug)]
 pub enum CoreBluetoothReply {
     ReadResult(Vec<u8>),
     Connected(BTreeSet<Characteristic>),
@@ -95,6 +112,7 @@ pub enum CoreBluetoothReply {
     Err(String),
 }
 
+#[derive(Debug)]
 pub enum CBPeripheralEvent {
     Disconnected,
     Notification(Uuid, Vec<u8>),
@@ -111,6 +129,22 @@ struct CBPeripheral {
     pub event_sender: Sender<CBPeripheralEvent>,
     pub connected_future_state: Option<CoreBluetoothReplyStateShared>,
     characteristic_update_count: u32,
+}
+
+impl Debug for CBPeripheral {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        f.debug_struct("CBPeripheral")
+            .field("peripheral", self.peripheral.deref())
+            .field("services", &self.services.keys().collect::<Vec<_>>())
+            .field("characteristics", &self.characteristics)
+            .field("event_sender", &self.event_sender)
+            .field("connected_future_state", &self.connected_future_state)
+            .field(
+                "characteristic_update_count",
+                &self.characteristic_update_count,
+            )
+            .finish()
+    }
 }
 
 impl CBPeripheral {
@@ -193,6 +227,20 @@ struct CoreBluetoothInternal {
     message_receiver: Receiver<CoreBluetoothMessage>,
 }
 
+impl Debug for CoreBluetoothInternal {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        f.debug_struct("CoreBluetoothInternal")
+            .field("manager", self.manager.deref())
+            .field("delegate", self.delegate.deref())
+            .field("peripherals", &self.peripherals)
+            .field("delegate_receiver", &self.delegate_receiver)
+            .field("event_sender", &self.event_sender)
+            .field("message_receiver", &self.message_receiver)
+            .finish()
+    }
+}
+
+#[derive(Debug)]
 pub enum CoreBluetoothMessage {
     StartScanning,
     StopScanning,
@@ -210,6 +258,7 @@ pub enum CoreBluetoothMessage {
     Unsubscribe(Uuid, Uuid, CoreBluetoothReplyStateShared),
 }
 
+#[derive(Debug)]
 pub enum CoreBluetoothEvent {
     AdapterConnected,
     AdapterError,
@@ -222,6 +271,7 @@ pub enum CoreBluetoothEvent {
 
 // Aggregate everything that can come in from different sources into a single
 // enum type.
+#[derive(Debug)]
 enum InternalLoopMessage {
     Delegate(CentralDelegateEvent),
     Adapter(CoreBluetoothMessage),

--- a/src/corebluetooth/manager.rs
+++ b/src/corebluetooth/manager.rs
@@ -8,6 +8,7 @@
 use super::adapter::Adapter;
 use crate::Result;
 
+#[derive(Clone, Debug)]
 pub struct Manager {}
 
 impl Manager {

--- a/src/corebluetooth/mod.rs
+++ b/src/corebluetooth/mod.rs
@@ -5,10 +5,6 @@
 // Licensed under the BSD 3-Clause license. See LICENSE file in the project root
 // for full license information.
 
-// mod ble;
-// pub mod manager;
-// pub mod adapter;
-// pub mod peripheral;
 pub mod adapter;
 mod central_delegate;
 mod framework;

--- a/src/corebluetooth/peripheral.rs
+++ b/src/corebluetooth/peripheral.rs
@@ -95,7 +95,6 @@ impl Peripheral {
         });
         Self {
             properties,
-
             manager,
             characteristics: Arc::new(Mutex::new(BTreeSet::new())),
             notification_handlers,

--- a/src/corebluetooth/peripheral.rs
+++ b/src/corebluetooth/peripheral.rs
@@ -123,12 +123,13 @@ impl Display for Peripheral {
 
 impl Debug for Peripheral {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        // let connected = if self.is_connected() { " connected" } else { "" };
-        // let properties = self.properties.lock().unwrap();
-        // let characteristics = self.characteristics.lock().unwrap();
-        // write!(f, "{} properties: {:?}, characteristics: {:?} {}", self.address, *properties,
-        //        *characteristics, connected)
-        write!(f, "Peripheral")
+        f.debug_struct("Peripheral")
+            .field("uuid", &self.uuid)
+            .field("characteristics", &self.characteristics)
+            .field("properties", &self.properties)
+            .field("event_receiver", &self.event_receiver)
+            .field("message_sender", &self.message_sender)
+            .finish()
     }
 }
 

--- a/src/corebluetooth/peripheral.rs
+++ b/src/corebluetooth/peripheral.rs
@@ -20,7 +20,7 @@ use crate::{
     Error, Result,
 };
 use async_std::{
-    channel::{self, Receiver, Sender},
+    channel::{Receiver, Sender},
     prelude::StreamExt,
     task,
 };
@@ -49,7 +49,7 @@ pub struct Peripheral {
 impl Peripheral {
     pub fn new(
         uuid: Uuid,
-        local_name: String,
+        local_name: Option<String>,
         manager: AdapterManager<Self>,
         event_receiver: Receiver<CBPeripheralEvent>,
         message_sender: Sender<CoreBluetoothMessage>,
@@ -61,7 +61,7 @@ impl Peripheral {
             // MacOS, so we make it up for now. This sucks.
             address: uuid_to_bdaddr(&uuid.to_string()),
             address_type: AddressType::Random,
-            local_name: Some(local_name),
+            local_name: local_name,
             tx_power_level: None,
             manufacturer_data: HashMap::new(),
             discovery_count: 1,

--- a/src/corebluetooth/utils.rs
+++ b/src/corebluetooth/utils.rs
@@ -16,16 +16,11 @@
 // This file may not be copied, modified, or distributed except
 // according to those terms.
 
-use std::ffi::{CStr, CString};
+use std::ffi::CStr;
 
 use objc::runtime::Object;
 
 use super::framework::{cb, nil, ns};
-
-pub const NOT_SUPPORTED_ERROR: &'static str = "Error! Not supported by blurmac!";
-pub const NO_PERIPHERAL_FOUND: &'static str = "Error! No peripheral found!";
-pub const NO_SERVICE_FOUND: &'static str = "Error! No service found!";
-pub const NO_CHARACTERISTIC_FOUND: &'static str = "Error! No characteristic found!";
 
 pub mod NSStringUtils {
     use super::*;
@@ -54,10 +49,6 @@ pub mod NSStringUtils {
                     .unwrap(),
             ))
         }
-    }
-
-    pub fn string_from_str(string: &str) -> *mut Object {
-        ns::string(CString::new(string).unwrap().as_ptr())
     }
 }
 

--- a/src/corebluetooth/utils.rs
+++ b/src/corebluetooth/utils.rs
@@ -43,6 +43,19 @@ pub mod NSStringUtils {
         }
     }
 
+    pub fn string_to_maybe_string(nsstring: *mut Object) -> Option<String> {
+        if nsstring == nil {
+            return None;
+        }
+        unsafe {
+            Some(String::from(
+                CStr::from_ptr(ns::string_utf8string(nsstring))
+                    .to_str()
+                    .unwrap(),
+            ))
+        }
+    }
+
     pub fn string_from_str(string: &str) -> *mut Object {
         ns::string(CString::new(string).unwrap().as_ptr())
     }


### PR DESCRIPTION
This cleans up several things on Mac OS:
* Adds a `Debug` implementation for many types.
* Removes some unused code and fixes some other warnings.
* Sets local_name to `None` rather than `Some("nil")` for devices without a name.
* Either logs or returns errors in some cases where they were being ignored (and causing compile warnings).

Let me know if you'd prefer it to be split into smaller PRs.