### PR TITLE
Use futures::channel::mpsc instead of async_std::channel.

### DIFF
--- a/src/corebluetooth/adapter.rs
+++ b/src/corebluetooth/adapter.rs
@@ -2,9 +2,10 @@ use super::internal::{run_corebluetooth_thread, CoreBluetoothEvent, CoreBluetoot
 use super::peripheral::Peripheral;
 use crate::api::{AdapterManager, BDAddr, Central, CentralEvent};
 use crate::Result;
-use async_std::{prelude::StreamExt, task};
+use async_std::task;
 use futures::channel::mpsc::{self, Sender};
 use futures::sink::SinkExt;
+use futures::stream::StreamExt;
 use log::info;
 use std::convert::TryInto;
 use std::sync::mpsc::Receiver;

--- a/src/corebluetooth/central_delegate.rs
+++ b/src/corebluetooth/central_delegate.rs
@@ -20,7 +20,6 @@ use super::{
     framework::{cb, nil, ns},
     utils::{CoreBluetoothUtils, NSStringUtils},
 };
-use async_std::task;
 use futures::channel::mpsc::{self, Receiver, Sender};
 use futures::sink::SinkExt;
 use libc::{c_char, c_void};
@@ -227,7 +226,7 @@ pub mod CentralDelegate {
 
     fn send_delegate_event(delegate: &mut Object, event: CentralDelegateEvent) {
         let mut sender = delegate_get_sender_clone(delegate);
-        task::block_on(async {
+        futures::executor::block_on(async {
             if let Err(e) = sender.send(event).await {
                 error!("Error sending delegate event: {}", e);
             }

--- a/src/corebluetooth/future.rs
+++ b/src/corebluetooth/future.rs
@@ -1,8 +1,8 @@
-use async_std::task::{Context, Poll, Waker};
 use core::pin::Pin;
 use log::debug;
 use std::future::Future;
 use std::sync::{Arc, Mutex};
+use std::task::{Context, Poll, Waker};
 
 /// Struct used for waiting on replies from the server.
 ///

--- a/src/corebluetooth/future.rs
+++ b/src/corebluetooth/future.rs
@@ -1,9 +1,7 @@
-use async_std::{
-    future::Future,
-    task::{Context, Poll, Waker},
-};
+use async_std::task::{Context, Poll, Waker};
 use core::pin::Pin;
 use log::debug;
+use std::future::Future;
 use std::sync::{Arc, Mutex};
 
 /// Struct used for waiting on replies from the server.

--- a/src/corebluetooth/internal.rs
+++ b/src/corebluetooth/internal.rs
@@ -301,9 +301,6 @@ impl CoreBluetoothInternal {
                     .await;
             }
         } else {
-            // if name.contains("LVS") {
-            //     self.connect_peripheral(*peripheral);
-            // }
             // Create our channels
             let (event_sender, event_receiver) = mpsc::channel(256);
             self.peripherals

--- a/src/corebluetooth/internal.rs
+++ b/src/corebluetooth/internal.rs
@@ -511,7 +511,7 @@ impl CoreBluetoothInternal {
         }
     }
 
-    async fn wait_for_message(&mut self) -> bool {
+    async fn wait_for_message(&mut self) {
         select! {
             delegate_msg = self.delegate_receiver.select_next_some() => {
                 match delegate_msg {
@@ -557,7 +557,6 @@ impl CoreBluetoothInternal {
                         characteristic_id,
                     ) => self.on_characteristic_written(peripheral_id, characteristic_id),
                 };
-                true
             }
             adapter_msg = self.message_receiver.select_next_some() => {
                 info!("Adapter message!");
@@ -586,7 +585,6 @@ impl CoreBluetoothInternal {
                         self.unsubscribe(peripheral_uuid, char_uuid, fut)
                     }
                 };
-                true
             }
         }
     }
@@ -625,9 +623,7 @@ pub fn run_corebluetooth_thread(
         task::block_on(async move {
             let mut cbi = CoreBluetoothInternal::new(receiver, event_sender);
             loop {
-                if !cbi.wait_for_message().await {
-                    break;
-                }
+                cbi.wait_for_message().await;
             }
         })
     });


### PR DESCRIPTION
This is multi producer single consumer whereas `async_std::channel` is multi producer multi consumer, so this change required some refactoring to stop cloning the receiver. I think the result is a bit cleaner too.

This is a step towards removing the `async_std` dependency and moving to Tokio.

The examples still seem to work fine, but it could do with some stress testing to make sure there aren't any concurrency bugs I've missed.

Helps with #45.