### PR TITLE
Clean up dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,13 +23,9 @@ path = "src/lib.rs"
 [dependencies]
 static_assertions = "1.1.0"
 libc = "0.2.85"
-bytes = "1.0.1"
-num = "0.3.1"
 log = "0.4.14"
-enum_primitive = "0.1.1"
 bitflags = "1.2.1"
 thiserror = "1.0.23"
-backtrace = "0.3"
 uuid = "0.8.2"
 serde = { version = "1.0.123", features = ["derive"], default-features = false, optional = true }
 dashmap = "4.0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,6 @@ path = "src/lib.rs"
 # crate-type = ["staticlib"]
 
 [dependencies]
-static_assertions = "1.1.0"
-libc = "0.2.85"
 log = "0.4.14"
 bitflags = "1.2.1"
 thiserror = "1.0.23"
@@ -30,22 +28,21 @@ uuid = "0.8.2"
 serde = { version = "1.0.123", features = ["derive"], default-features = false, optional = true }
 dashmap = "4.0.2"
 futures = "0.3.12"
-parking_lot = "0.11.1"
-displaydoc = "0.1.7"
-winrt = "0.7.2"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 dbus = "0.9.1"
+displaydoc = "0.1.7"
+parking_lot = "0.11.1"
+static_assertions = "1.1.0"
 
-[target.'cfg(target_os = "macos")'.dependencies]
+[target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 async-std = "1.9.0"
-objc = "0.2.7"
 cocoa = "0.24.0"
+objc = "0.2.7"
+libc = "0.2.85"
 
-[target.'cfg(target_os = "ios")'.dependencies]
-async-std = "1.9.0"
-objc = "0.2.7"
-cocoa = "0.24.0"
+[target.'cfg(target_os = "windows")'.dependencies]
+winrt = "0.7.2"
 
 [dev-dependencies]
 simple_logger = "1.11.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ path = "src/lib.rs"
 [dependencies]
 static_assertions = "1.1.0"
 libc = "0.2.85"
-nix = "0.19.1"
 bytes = "1.0.1"
 num = "0.3.1"
 log = "0.4.14"

--- a/src/api/adapter_manager.rs
+++ b/src/api/adapter_manager.rs
@@ -127,6 +127,6 @@ where
     pub fn peripheral(&self, address: BDAddr) -> Option<PeripheralType> {
         self.peripherals
             .get(&address)
-            .and_then(|val| Some(val.value().clone()))
+            .map(|val| val.value().clone())
     }
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -19,6 +19,7 @@ use crate::{
     api::UUID::{B128, B16},
     Error, Result,
 };
+use bitflags::bitflags;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use std::sync::mpsc::Receiver;

--- a/src/bluez/adapter/mod.rs
+++ b/src/bluez/adapter/mod.rs
@@ -22,6 +22,11 @@ use super::{
     bluez_dbus::gatt_characteristic::ORG_BLUEZ_GATT_CHARACTERISTIC1_NAME,
     bluez_dbus::gatt_service::ORG_BLUEZ_GATT_SERVICE1_NAME, BLUEZ_DEST, DEFAULT_TIMEOUT,
 };
+use crate::{
+    api::{AdapterManager, BDAddr, Central, CentralEvent, CharPropFlags, UUID},
+    bluez::adapter::peripheral::Peripheral,
+    Error, Result,
+};
 use dashmap::DashMap;
 use dbus::{
     arg::RefArg,
@@ -30,7 +35,10 @@ use dbus::{
     message::SignalArgs,
     Path,
 };
-
+use displaydoc::Display;
+use log::{debug, error, info, trace, warn};
+use parking_lot::ReentrantMutex;
+use static_assertions::assert_impl_all;
 use std::{
     self,
     iter::Iterator,
@@ -39,17 +47,6 @@ use std::{
     thread::{self, JoinHandle},
     time::Duration,
 };
-
-use parking_lot::ReentrantMutex;
-
-use crate::{api::UUID, Result};
-use crate::{
-    api::{AdapterManager, BDAddr, Central, CentralEvent, CharPropFlags},
-    Error,
-};
-
-use crate::bluez::adapter::peripheral::Peripheral;
-use displaydoc::Display;
 use thiserror::Error;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]

--- a/src/bluez/adapter/peripheral.rs
+++ b/src/bluez/adapter/peripheral.rs
@@ -11,14 +11,6 @@
 //
 // Copyright (c) 2014 The Rust Project Developers
 
-use dbus::{
-    arg::{cast, PropMap, RefArg, Variant},
-    blocking::{stdintf::org_freedesktop_dbus::PropertiesPropertiesChanged, Proxy, SyncConnection},
-    channel::Token,
-    message::{Message, SignalArgs},
-    Path,
-};
-
 use crate::{
     api::{
         AdapterManager, AddressType, BDAddr, CentralEvent, CharPropFlags, Characteristic,
@@ -33,7 +25,15 @@ use crate::{
     common::util::invoke_handlers,
     Error, Result,
 };
-
+use dbus::{
+    arg::{cast, PropMap, RefArg, Variant},
+    blocking::{stdintf::org_freedesktop_dbus::PropertiesPropertiesChanged, Proxy, SyncConnection},
+    channel::Token,
+    message::{Message, SignalArgs},
+    Path,
+};
+use log::{debug, error, trace, warn};
+use static_assertions::assert_impl_all;
 use std::{
     collections::{BTreeSet, HashMap},
     fmt::{self, Debug, Display, Formatter},

--- a/src/bluez/manager/mod.rs
+++ b/src/bluez/manager/mod.rs
@@ -11,13 +11,11 @@
 //
 // Copyright (c) 2014 The Rust Project Developers
 
-use std::sync::Arc;
-
-use dbus::blocking::{stdintf::org_freedesktop_dbus::ObjectManager, SyncConnection};
-
-use crate::{bluez::adapter::Adapter, Result};
-
 use super::{bluez_dbus::adapter::ORG_BLUEZ_ADAPTER1_NAME, BLUEZ_DEST, DEFAULT_TIMEOUT};
+use crate::{bluez::adapter::Adapter, Result};
+use dbus::blocking::{stdintf::org_freedesktop_dbus::ObjectManager, SyncConnection};
+use static_assertions::assert_impl_all;
+use std::sync::Arc;
 
 /// This struct is the interface into BlueZ. It can be used to list, manage, and connect to bluetooth
 /// adapters.

--- a/src/corebluetooth/adapter.rs
+++ b/src/corebluetooth/adapter.rs
@@ -7,6 +7,7 @@ use async_std::{
     prelude::StreamExt,
     task,
 };
+use log::info;
 use std::convert::TryInto;
 use std::sync::mpsc::Receiver;
 

--- a/src/corebluetooth/central_delegate.rs
+++ b/src/corebluetooth/central_delegate.rs
@@ -31,6 +31,7 @@ use objc::{
     rc::StrongPtr,
     runtime::{Class, Object, Protocol, Sel},
 };
+use objc::{msg_send, sel, sel_impl};
 use std::ffi::CStr;
 use std::{
     collections::HashMap,

--- a/src/corebluetooth/central_delegate.rs
+++ b/src/corebluetooth/central_delegate.rs
@@ -16,10 +16,22 @@
 // This file may not be copied, modified, or distributed except
 // according to those terms.
 
+use super::{
+    framework::{cb, nil, ns},
+    utils::{CoreBluetoothUtils, NSStringUtils},
+};
 use async_std::{
     channel::{Receiver, Sender},
     task,
 };
+use libc::{c_char, c_void};
+use log::{error, info, trace};
+use objc::{
+    declare::ClassDecl,
+    rc::StrongPtr,
+    runtime::{Class, Object, Protocol, Sel},
+};
+use std::ffi::CStr;
 use std::{
     collections::HashMap,
     fmt::{self, Debug, Formatter},
@@ -28,22 +40,7 @@ use std::{
     str::FromStr,
     sync::Once,
 };
-
-use objc::{
-    declare::ClassDecl,
-    rc::StrongPtr,
-    runtime::{Class, Object, Protocol, Sel},
-};
-
-use super::{
-    framework::{cb, nil, ns},
-    utils::{CoreBluetoothUtils, NSStringUtils},
-};
-
 use uuid::Uuid;
-
-use libc::{c_char, c_void};
-use std::ffi::CStr;
 
 pub enum CentralDelegateEvent {
     DidUpdateState,

--- a/src/corebluetooth/framework.rs
+++ b/src/corebluetooth/framework.rs
@@ -16,9 +16,9 @@
 // This file may not be copied, modified, or distributed except
 // according to those terms.
 
-use std::os::raw::{c_char, c_int, c_uint};
-
 use objc::runtime::{Class, Object, BOOL};
+use objc::{msg_send, sel, sel_impl};
+use std::os::raw::{c_char, c_int, c_uint};
 
 #[allow(non_upper_case_globals)]
 pub const nil: *mut Object = 0 as *mut Object;

--- a/src/corebluetooth/future.rs
+++ b/src/corebluetooth/future.rs
@@ -3,6 +3,7 @@ use async_std::{
     task::{Context, Poll, Waker},
 };
 use core::pin::Pin;
+use log::debug;
 use std::sync::{Arc, Mutex};
 
 /// Struct used for waiting on replies from the server.

--- a/src/corebluetooth/internal.rs
+++ b/src/corebluetooth/internal.rs
@@ -20,6 +20,7 @@ use async_std::{
     task,
 };
 use futures::{select, FutureExt, StreamExt};
+use log::{error, info, trace};
 use objc::{
     rc::StrongPtr,
     runtime::{Object, YES},

--- a/src/corebluetooth/peripheral.rs
+++ b/src/corebluetooth/peripheral.rs
@@ -24,6 +24,7 @@ use async_std::{
     prelude::StreamExt,
     task,
 };
+use log::{debug, error, info};
 use std::{
     collections::{BTreeSet, HashMap},
     fmt::{self, Debug, Display, Formatter},

--- a/src/corebluetooth/utils.rs
+++ b/src/corebluetooth/utils.rs
@@ -23,7 +23,6 @@ use uuid::Uuid;
 use super::framework::{cb, nil, ns};
 
 pub mod NSStringUtils {
-
     use super::*;
 
     pub fn string_to_string(nsstring: *mut Object) -> String {
@@ -115,6 +114,7 @@ pub mod CoreBluetoothUtils {
 #[cfg(test)]
 mod tests {
     use objc::runtime::Class;
+    use objc::{msg_send, sel, sel_impl};
     use CoreBluetoothUtils::cbuuid_to_uuid;
     use NSStringUtils::str_to_nsstring;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,10 +80,6 @@ extern crate libc;
 #[cfg(target_os = "windows")]
 extern crate winrt;
 
-#[cfg(any(target_os = "macos", target_os = "ios"))]
-#[macro_use]
-extern crate objc;
-
 // We won't actually use anything specifically out of this crate. However, if we
 // want the CoreBluetooth code to compile, we need the objc protocols
 // (specifically, the core bluetooth protocols) exposed by it.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,9 +77,6 @@
 
 extern crate libc;
 
-#[cfg(target_os = "linux")]
-extern crate nix;
-
 #[cfg(target_os = "windows")]
 extern crate winrt;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,9 +20,6 @@
 //! An example of how to use the library to control some BLE smart lights:
 //!
 //! ```rust,no_run
-//! extern crate btleplug;
-//! extern crate rand;
-//!
 //! use std::thread;
 //! use std::time::Duration;
 //! use rand::{Rng, thread_rng};
@@ -75,8 +72,6 @@
 //! }
 //! ```
 
-extern crate libc;
-
 #[cfg(target_os = "windows")]
 extern crate winrt;
 
@@ -85,14 +80,6 @@ extern crate winrt;
 // (specifically, the core bluetooth protocols) exposed by it.
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 extern crate cocoa;
-
-extern crate bytes;
-
-#[cfg(target_os = "linux")]
-extern crate enum_primitive;
-extern crate num;
-
-extern crate thiserror;
 
 use std::result;
 use std::time::Duration;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,13 +77,6 @@
 
 extern crate libc;
 
-#[macro_use]
-extern crate log;
-
-#[cfg(target_os = "linux")]
-#[macro_use]
-extern crate static_assertions;
-
 #[cfg(target_os = "linux")]
 extern crate nix;
 
@@ -105,9 +98,6 @@ extern crate bytes;
 #[cfg(target_os = "linux")]
 extern crate enum_primitive;
 extern crate num;
-
-#[macro_use]
-extern crate bitflags;
 
 extern crate thiserror;
 

--- a/src/winrtble/ble/characteristic.rs
+++ b/src/winrtble/ble/characteristic.rs
@@ -12,7 +12,7 @@
 // Copyright (c) 2014 The Rust Project Developers
 
 use super::super::bindings;
-use crate::{Error, Result, api::WriteType};
+use crate::{api::WriteType, Error, Result};
 
 use bindings::windows::devices::bluetooth::generic_attribute_profile::{
     GattCharacteristic, GattClientCharacteristicConfigurationDescriptorValue,
@@ -20,6 +20,7 @@ use bindings::windows::devices::bluetooth::generic_attribute_profile::{
 };
 use bindings::windows::foundation::{EventRegistrationToken, TypedEventHandler};
 use bindings::windows::storage::streams::{DataReader, DataWriter};
+use log::info;
 
 pub type NotifiyEventHandler = Box<dyn Fn(Vec<u8>) + Send>;
 

--- a/src/winrtble/ble/device.rs
+++ b/src/winrtble/ble/device.rs
@@ -18,6 +18,7 @@ use bindings::windows::devices::bluetooth::generic_attribute_profile::{
 };
 use bindings::windows::devices::bluetooth::{BluetoothConnectionStatus, BluetoothLEDevice};
 use bindings::windows::foundation::{EventRegistrationToken, TypedEventHandler};
+use log::info;
 
 pub type ConnectedEventHandler = Box<dyn Fn(bool) + Send>;
 


### PR DESCRIPTION
This removes some unnecessary dependencies, moves some to only the platforms that actually require them, and removes 2015 edition style `extern crate` declarations in favour of using macros individually.