### PR TITLE
Fix ordering of Characteristic display.

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -277,7 +277,7 @@ impl Display for Characteristic {
         write!(
             f,
             "uuid: {:?}, char properties: {:?}",
-            self.properties, self.uuid
+            self.uuid, self.properties
         )
     }
 }


### PR DESCRIPTION
Just a quick simple fix, I noticed the ordering was wrong in the Characteristic display function.