### PR TITLE
[Feature] Advertisement support for Service Data, Manufacturer Data and Services

### DIFF
--- a/examples/event_driven_discovery.rs
+++ b/examples/event_driven_discovery.rs
@@ -1,7 +1,7 @@
 extern crate btleplug;
 extern crate rand;
 
-use btleplug::api::{Central, CentralEvent};
+use btleplug::api::{bleuuid::BleUuid, Central, CentralEvent};
 #[cfg(target_os = "linux")]
 use btleplug::bluez::{adapter::Adapter, manager::Manager};
 #[cfg(target_os = "macos")]
@@ -51,6 +51,33 @@ pub fn main() {
             }
             CentralEvent::DeviceDisconnected(bd_addr) => {
                 println!("DeviceDisconnected: {:?}", bd_addr);
+            }
+            CentralEvent::ManufacturerDataAdvertisement {
+                address,
+                manufacturer_id,
+                data,
+            } => {
+                println!(
+                    "ManufacturerDataAdvertisement: {:?}, {}, {:?}",
+                    address, manufacturer_id, data
+                );
+            }
+            CentralEvent::ServiceDataAdvertisement {
+                address,
+                service,
+                data,
+            } => {
+                println!(
+                    "ServiceDataAdvertisement: {:?}, {}, {:?}",
+                    address,
+                    service.to_short_string(),
+                    data
+                );
+            }
+            CentralEvent::ServicesAdvertisement { address, services } => {
+                let services: Vec<String> =
+                    services.into_iter().map(|s| s.to_short_string()).collect();
+                println!("ServicesAdvertisement: {:?}, {:?}", address, services);
             }
             _ => {}
         }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -222,6 +222,11 @@ pub struct PeripheralProperties {
     /// Advertisement data specific to the device manufacturer. The keys of this map are
     /// 'manufacturer IDs', while the values are arbitrary data.
     pub manufacturer_data: HashMap<u16, Vec<u8>>,
+    /// Advertisement data specific to a service. The keys of this map are
+    /// 'Service UUIDs', while the values are arbitrary data.
+    pub service_data: HashMap<Uuid, Vec<u8>>,
+    /// Advertised services for this device
+    pub services: Vec<Uuid>,
     /// Number of times we've seen advertising reports for this device
     pub discovery_count: u32,
     /// True if we've discovered the device before
@@ -301,13 +306,30 @@ pub trait Peripheral: Send + Sync + Clone + Debug {
 }
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Clone)]
 pub enum CentralEvent {
     DeviceDiscovered(BDAddr),
     DeviceLost(BDAddr),
     DeviceUpdated(BDAddr),
     DeviceConnected(BDAddr),
     DeviceDisconnected(BDAddr),
+    /// Emitted when a Manufacturer Data advertisement has been received from a device
+    ManufacturerDataAdvertisement {
+        address: BDAddr,
+        manufacturer_id: u16,
+        data: Vec<u8>,
+    },
+    /// Emitted when a Service Data advertisement has been received from a device
+    ServiceDataAdvertisement {
+        address: BDAddr,
+        service: Uuid,
+        data: Vec<u8>,
+    },
+    /// Emitted when the advertised services for a device has been updated
+    ServicesAdvertisement {
+        address: BDAddr,
+        services: Vec<Uuid>,
+    },
 }
 
 /// Central is the "client" of BLE. It's able to scan for and establish connections to peripherals.

--- a/src/bluez/adapter/peripheral.rs
+++ b/src/bluez/adapter/peripheral.rs
@@ -237,6 +237,7 @@ impl Peripheral {
     pub fn update_properties(&self, args: OrgBluezDevice1Properties) {
         trace!("Updating peripheral properties");
         let mut properties = self.properties.lock().unwrap();
+        let mut emit_updated = false;
 
         properties.discovery_count += 1;
 
@@ -266,6 +267,7 @@ impl Peripheral {
         if let Some(name) = args.name() {
             debug!("Updating \"{}\" local name to \"{:?}\"", self.address, name);
             properties.local_name = Some(name.to_owned());
+            emit_updated = true;
         }
 
         if let Some(services_resolved) = args.services_resolved() {
@@ -281,18 +283,6 @@ impl Peripheral {
             cvar.notify_all();
         }
 
-        // if let Some(services) = args.get("ServiceData") {
-        //     debug!("Updating services to \"{:?}\"", services);
-
-        //     if let Some(mut iter) = services.0.as_iter() {
-        //         loop {
-        //             if let (Some(uuid), ())
-        //         }
-        //     }
-        // }
-
-        // As of writing this: ManufacturerData returns a 'Variant({<manufacturer_id>: Variant([<manufacturer_data>])})'.
-        // This Variant wrapped dictionary and array is difficult to navigate. So uh.. trust me, this works on my machine™.
         if let Some(manufacturer_data) = args.manufacturer_data() {
             debug!(
                 "Updating \"{}\" manufacturer data \"{:?}\"",
@@ -302,6 +292,12 @@ impl Peripheral {
                 .into_iter()
                 .filter_map(|(&k, v)| {
                     if let Some(v) = cast::<Vec<u8>>(&v.0) {
+                        self.adapter
+                            .emit(CentralEvent::ManufacturerDataAdvertisement {
+                                address: self.address(),
+                                manufacturer_id: k,
+                                data: v.clone(),
+                            });
                         Some((k, v.to_owned()))
                     } else {
                         warn!("Manufacturer data had wrong type: {:?}", &v.0);
@@ -309,6 +305,38 @@ impl Peripheral {
                     }
                 })
                 .collect();
+        }
+
+        if let Some(service_data) = args.service_data() {
+            properties.service_data = service_data
+                .into_iter()
+                .filter_map(|(service, data)| {
+                    let service: Uuid = service.parse().unwrap();
+                    if let Some(data) = cast::<Vec<u8>>(&data.0) {
+                        self.adapter.emit(CentralEvent::ServiceDataAdvertisement {
+                            address: self.address(),
+                            service,
+                            data: data.clone(),
+                        });
+                        Some((service, data.to_owned()))
+                    } else {
+                        warn!("Service data had wrong type: {:?}", &data.0);
+                        None
+                    }
+                })
+                .collect();
+        }
+
+        if let Some(services) = args.uuids() {
+            properties.services = services
+                .into_iter()
+                .filter_map(|uuid| uuid.parse().ok())
+                .collect();
+
+            self.adapter.emit(CentralEvent::ServicesAdvertisement {
+                address: self.address.clone(),
+                services: properties.services.clone(),
+            });
         }
 
         if let Some(address_type) = args.address_type() {
@@ -320,15 +348,19 @@ impl Peripheral {
             );
 
             properties.address_type = address_type;
+            emit_updated = true;
         }
 
         if let Some(rssi) = args.rssi() {
             let rssi = rssi as i8;
             debug!("Updating \"{}\" RSSI \"{:?}\"", self.address, rssi);
             properties.tx_power_level = Some(rssi);
+            emit_updated = true;
         }
 
-        self.adapter.emit(CentralEvent::DeviceUpdated(self.address));
+        if emit_updated {
+            self.adapter.emit(CentralEvent::DeviceUpdated(self.address));
+        }
     }
 
     pub fn proxy(&self) -> Proxy<&SyncConnection> {

--- a/src/corebluetooth/central_delegate.rs
+++ b/src/corebluetooth/central_delegate.rs
@@ -410,7 +410,7 @@ pub mod CentralDelegate {
             cb::ADVERTISEMENT_DATA_SERVICE_UUIDS_KEY
         });
         if services != nil {
-            // service_data: [CBUUID, NSData]
+            // services: [CBUUID]
             let mut result = Vec::new();
             for i in 0..ns::array_count(services) {
                 let uuid = ns::array_objectatindex(services, i);

--- a/src/corebluetooth/framework.rs
+++ b/src/corebluetooth/framework.rs
@@ -271,6 +271,8 @@ pub mod cb {
 
         #[link(name = "CoreBluetooth", kind = "framework")]
         extern "C" {
+            pub static CBAdvertisementDataManufacturerDataKey: *mut Object;
+            pub static CBAdvertisementDataServiceDataKey: *mut Object;
             pub static CBAdvertisementDataServiceUUIDsKey: *mut Object;
 
             pub static CBCentralManagerScanOptionAllowDuplicatesKey: *mut Object;
@@ -522,5 +524,7 @@ pub mod cb {
 
     // CBAdvertisementData...Key
 
-    pub use self::link::CBAdvertisementDataServiceUUIDsKey as ADVERTISEMENTDATASERVICEUUIDSKEY;
+    pub use self::link::CBAdvertisementDataManufacturerDataKey as ADVERTISEMENT_DATA_MANUFACTURER_DATA_KEY;
+    pub use self::link::CBAdvertisementDataServiceDataKey as ADVERTISEMENT_DATA_SERVICE_DATA_KEY;
+    pub use self::link::CBAdvertisementDataServiceUUIDsKey as ADVERTISEMENT_DATA_SERVICE_UUIDS_KEY;
 }

--- a/src/corebluetooth/peripheral.rs
+++ b/src/corebluetooth/peripheral.rs
@@ -38,7 +38,7 @@ pub struct Peripheral {
     manager: AdapterManager<Self>,
     uuid: Uuid,
     characteristics: Arc<Mutex<BTreeSet<Characteristic>>>,
-    pub(crate) properties: PeripheralProperties,
+    pub(crate) properties: Arc<Mutex<PeripheralProperties>>,
     message_sender: Sender<CoreBluetoothMessage>,
     // We're not actually holding a peripheral object here, that's held out in
     // the objc thread. We'll just communicate with it through our
@@ -55,7 +55,7 @@ impl Peripheral {
     ) -> Self {
         // Since we're building the object, we have an active advertisement.
         // Build properties now.
-        let properties = PeripheralProperties {
+        let properties = Arc::new(Mutex::from(PeripheralProperties {
             // Rumble required ONLY a BDAddr, not something you can get from
             // MacOS, so we make it up for now. This sucks.
             address: uuid_to_bdaddr(&uuid.to_string()),
@@ -63,30 +63,67 @@ impl Peripheral {
             local_name: local_name,
             tx_power_level: None,
             manufacturer_data: HashMap::new(),
+            service_data: HashMap::new(),
+            services: Vec::new(),
             discovery_count: 1,
             has_scan_response: true,
-        };
+        }));
         let notification_handlers = Arc::new(Mutex::new(Vec::<NotificationHandler>::new()));
         let nh_clone = notification_handlers.clone();
+        let p_clone = properties.clone();
+        let m_clone = manager.clone();
         task::spawn(async move {
             let mut event_receiver = event_receiver;
             loop {
-                let event = event_receiver.next().await;
-                if event.is_none() {
+                if let Some(event) = event_receiver.next().await {
+                    match event {
+                        CBPeripheralEvent::Notification(uuid, data) => {
+                            util::invoke_handlers(
+                                &nh_clone,
+                                &ValueNotification {
+                                    uuid,
+                                    handle: None,
+                                    value: data,
+                                },
+                            );
+                        }
+                        CBPeripheralEvent::ManufacturerData(manufacturer_id, data) => {
+                            let mut properties = p_clone.lock().unwrap();
+                            properties
+                                .manufacturer_data
+                                .insert(manufacturer_id, data.clone());
+                            m_clone.emit(CentralEvent::ManufacturerDataAdvertisement {
+                                address: properties.address,
+                                manufacturer_id,
+                                data,
+                            });
+                        }
+                        CBPeripheralEvent::ServiceData(service_data) => {
+                            let mut properties = p_clone.lock().unwrap();
+                            properties.service_data.extend(service_data.clone());
+
+                            for (service, data) in service_data.into_iter() {
+                                m_clone.emit(CentralEvent::ServiceDataAdvertisement {
+                                    address: properties.address,
+                                    service,
+                                    data,
+                                });
+                            }
+                        }
+                        CBPeripheralEvent::Services(services) => {
+                            let mut properties = p_clone.lock().unwrap();
+                            properties.services = services.clone();
+
+                            m_clone.emit(CentralEvent::ServicesAdvertisement {
+                                address: properties.address,
+                                services,
+                            });
+                        }
+                        CBPeripheralEvent::Disconnected => (),
+                    }
+                } else {
                     error!("Event receiver died, breaking out of corebluetooth device loop.");
                     break;
-                }
-                if let Some(CBPeripheralEvent::Notification(uuid, data)) = event {
-                    util::invoke_handlers(
-                        &nh_clone,
-                        &ValueNotification {
-                            uuid,
-                            handle: None,
-                            value: data,
-                        },
-                    );
-                } else {
-                    error!("Unhandled CBPeripheralEvent");
                 }
             }
         });
@@ -130,13 +167,13 @@ impl Debug for Peripheral {
 impl ApiPeripheral for Peripheral {
     /// Returns the address of the peripheral.
     fn address(&self) -> BDAddr {
-        self.properties.address
+        self.properties.lock().unwrap().address
     }
 
     /// Returns the set of properties associated with the peripheral. These may be updated over time
     /// as additional advertising reports are received.
     fn properties(&self) -> PeripheralProperties {
-        self.properties.clone()
+        self.properties.lock().unwrap().clone()
     }
 
     /// The set of characteristics we've discovered for this device. This will be empty until
@@ -167,7 +204,9 @@ impl ApiPeripheral for Peripheral {
             match fut.await {
                 CoreBluetoothReply::Connected(chars) => {
                     *(self.characteristics.lock().unwrap()) = chars;
-                    self.emit(CentralEvent::DeviceConnected(self.properties.address));
+                    self.emit(CentralEvent::DeviceConnected(
+                        self.properties.lock().unwrap().address,
+                    ));
                 }
                 _ => panic!("Shouldn't get anything but connected!"),
             }

--- a/src/winrtble/mod.rs
+++ b/src/winrtble/mod.rs
@@ -17,3 +17,10 @@ mod ble;
 pub mod manager;
 pub mod peripheral;
 pub mod utils;
+
+/// Only some of the assigned numbers are populated here as needed from https://www.bluetooth.com/specifications/assigned-numbers/generic-access-profile/
+mod advertisement_data_type {
+    pub const SERVICE_DATA_16_BIT_UUID: u8 = 0x16;
+    pub const SERVICE_DATA_32_BIT_UUID: u8 = 0x20;
+    pub const SERVICE_DATA_128_BIT_UUID: u8 = 0x21;
+}

--- a/src/winrtble/utils.rs
+++ b/src/winrtble/utils.rs
@@ -16,8 +16,11 @@ use crate::{
     api::{BDAddr, CharPropFlags},
     Error, Result,
 };
-use bindings::windows::devices::bluetooth::generic_attribute_profile::{
-    GattCharacteristicProperties, GattCommunicationStatus,
+use bindings::windows::{
+    devices::bluetooth::generic_attribute_profile::{
+        GattCharacteristicProperties, GattCommunicationStatus,
+    },
+    storage::streams::{DataReader, IBuffer},
 };
 use std::str::FromStr;
 use uuid::Uuid;
@@ -56,6 +59,14 @@ pub fn to_address(addr: BDAddr) -> u64 {
 pub fn to_uuid(uuid: &Guid) -> Uuid {
     let guid_s = format!("{:?}", uuid);
     Uuid::from_str(&guid_s).unwrap()
+}
+
+pub fn to_vec(buffer: &IBuffer) -> Vec<u8> {
+    let reader = DataReader::from_buffer(buffer).unwrap();
+    let len = reader.unconsumed_buffer_length().unwrap() as usize;
+    let mut data = vec![0u8; len];
+    reader.read_bytes(&mut data).unwrap();
+    data
 }
 
 pub fn to_guid(uuid: &Uuid) -> Guid {


### PR DESCRIPTION
Bluetooth advertisement may also contain Service Data (that is, Service UUIDs followed by arbitrary bytes) and advertised services. 
This Merge Request adds 
1. `service_data` and `services` to `btleplug::api::PeripheralPropties` 
2. `ManufacturerDataAdvertisement`, `ServiceDataAdvertisement` and `ServiceSAdvertisement` to `btleplug::api::CentralEvent`
3. Emits appropriate events from BlueZ, WinRT and Core Bluetooth
   - WinRT requried some manual parsing as there isn't a direct API for Service Data
   - Core Bluetooth didn't implement manufacturer data, so that was also added