### PR TITLE
Fix serde support for Uuid type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,12 +20,15 @@ name = "btleplug"
 path = "src/lib.rs"
 # crate-type = ["staticlib"]
 
+[features]
+serde = ["uuid/serde", "serde_cr"]
+
 [dependencies]
 log = "0.4.14"
 bitflags = "1.2.1"
 thiserror = "1.0.23"
 uuid = "0.8.2"
-serde = { version = "1.0.123", features = ["derive"], default-features = false, optional = true }
+serde_cr = { package = "serde", version = "1.0.123", features = ["derive"], default-features = false, optional = true }
 dashmap = "4.0.2"
 futures = "0.3.12"
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -18,6 +18,8 @@ use crate::{Error, Result};
 pub use adapter_manager::AdapterManager;
 use bitflags::bitflags;
 #[cfg(feature = "serde")]
+extern crate serde_cr as serde;
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use std::sync::mpsc::Receiver;
 use std::{
@@ -29,7 +31,11 @@ use std::{
 use thiserror::Error;
 use uuid::Uuid;
 
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_cr")
+)]
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum AddressType {
     Random,
@@ -68,7 +74,11 @@ impl AddressType {
 }
 
 /// Stores the 6 byte address used to identify Bluetooth devices.
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_cr")
+)]
 #[derive(Copy, Clone, Hash, Eq, PartialEq, Default)]
 #[repr(C)]
 pub struct BDAddr {
@@ -305,7 +315,11 @@ pub trait Peripheral: Send + Sync + Clone + Debug {
     fn on_notification(&self, handler: NotificationHandler);
 }
 
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_cr")
+)]
 #[derive(Debug, Clone)]
 pub enum CentralEvent {
     DeviceDiscovered(BDAddr),

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -18,9 +18,9 @@ use crate::{Error, Result};
 pub use adapter_manager::AdapterManager;
 use bitflags::bitflags;
 #[cfg(feature = "serde")]
-extern crate serde_cr as serde;
-#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "serde")]
+use serde_cr as serde;
 use std::sync::mpsc::Receiver;
 use std::{
     collections::{BTreeSet, HashMap},


### PR DESCRIPTION
To maintain a `serde` feature with the btleplug package, some package
renaming magic needed to happen. See
- https://blog.turbo.fish/cargo-features/
- https://github.com/serde-rs/serde/issues/1990