### PR TITLE
Fix emitting individual manufacturer data and service data

### DIFF
--- a/examples/event_driven_discovery.rs
+++ b/examples/event_driven_discovery.rs
@@ -54,24 +54,20 @@ pub fn main() {
             }
             CentralEvent::ManufacturerDataAdvertisement {
                 address,
-                manufacturer_id,
-                data,
+                manufacturer_data,
             } => {
                 println!(
-                    "ManufacturerDataAdvertisement: {:?}, {}, {:?}",
-                    address, manufacturer_id, data
+                    "ManufacturerDataAdvertisement: {:?}, {:?}",
+                    address, manufacturer_data
                 );
             }
             CentralEvent::ServiceDataAdvertisement {
                 address,
-                service,
-                data,
+                service_data,
             } => {
                 println!(
-                    "ServiceDataAdvertisement: {:?}, {}, {:?}",
-                    address,
-                    service.to_short_string(),
-                    data
+                    "ServiceDataAdvertisement: {:?}, {:?}",
+                    address, service_data
                 );
             }
             CentralEvent::ServicesAdvertisement { address, services } => {

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -330,14 +330,12 @@ pub enum CentralEvent {
     /// Emitted when a Manufacturer Data advertisement has been received from a device
     ManufacturerDataAdvertisement {
         address: BDAddr,
-        manufacturer_id: u16,
-        data: Vec<u8>,
+        manufacturer_data: HashMap<u16, Vec<u8>>,
     },
     /// Emitted when a Service Data advertisement has been received from a device
     ServiceDataAdvertisement {
         address: BDAddr,
-        service: Uuid,
-        data: Vec<u8>,
+        service_data: HashMap<Uuid, Vec<u8>>,
     },
     /// Emitted when the advertised services for a device has been updated
     ServicesAdvertisement {

--- a/src/bluez/adapter/peripheral.rs
+++ b/src/bluez/adapter/peripheral.rs
@@ -294,12 +294,6 @@ impl Peripheral {
                 .iter()
                 .filter_map(|(&k, v)| {
                     if let Some(v) = cast::<Vec<u8>>(&v.0) {
-                        self.adapter
-                            .emit(CentralEvent::ManufacturerDataAdvertisement {
-                                address: self.address(),
-                                manufacturer_id: k,
-                                data: v.clone(),
-                            });
                         Some((k, v.to_owned()))
                     } else {
                         warn!("Manufacturer data had wrong type: {:?}", &v.0);
@@ -307,6 +301,11 @@ impl Peripheral {
                     }
                 })
                 .collect();
+            self.adapter
+                .emit(CentralEvent::ManufacturerDataAdvertisement {
+                    address: self.address(),
+                    manufacturer_data: properties.manufacturer_data.clone(),
+                });
         }
 
         if let Some(service_data) = args.service_data() {
@@ -315,11 +314,6 @@ impl Peripheral {
                 .filter_map(|(service, data)| {
                     let service: Uuid = service.parse().unwrap();
                     if let Some(data) = cast::<Vec<u8>>(&data.0) {
-                        self.adapter.emit(CentralEvent::ServiceDataAdvertisement {
-                            address: self.address(),
-                            service,
-                            data: data.clone(),
-                        });
                         Some((service, data.to_owned()))
                     } else {
                         warn!("Service data had wrong type: {:?}", &data.0);
@@ -327,6 +321,10 @@ impl Peripheral {
                     }
                 })
                 .collect();
+            self.adapter.emit(CentralEvent::ServiceDataAdvertisement {
+                address: self.address(),
+                service_data: properties.service_data.clone(),
+            });
         }
 
         if let Some(services) = args.uuids() {

--- a/src/corebluetooth/peripheral.rs
+++ b/src/corebluetooth/peripheral.rs
@@ -93,21 +93,17 @@ impl Peripheral {
                             .insert(manufacturer_id, data.clone());
                         m_clone.emit(CentralEvent::ManufacturerDataAdvertisement {
                             address: properties.address,
-                            manufacturer_id,
-                            data,
+                            manufacturer_data: properties.manufacturer_data.clone(),
                         });
                     }
                     Some(CBPeripheralEvent::ServiceData(service_data)) => {
                         let mut properties = p_clone.lock().unwrap();
                         properties.service_data.extend(service_data.clone());
 
-                        for (service, data) in service_data.into_iter() {
-                            m_clone.emit(CentralEvent::ServiceDataAdvertisement {
-                                address: properties.address,
-                                service,
-                                data,
-                            });
-                        }
+                        m_clone.emit(CentralEvent::ServiceDataAdvertisement {
+                            address: properties.address,
+                            service_data,
+                        });
                     }
                     Some(CBPeripheralEvent::Services(services)) => {
                         let mut properties = p_clone.lock().unwrap();


### PR DESCRIPTION
With the recent  #126, `CentralEvent::ManufacturerDataAdvertisement` and `CentralEvent::ServiceDataAdvertisement` were emitted for the individually paired _manufacturer data_ and _service data_ received. Not ideal when they often provided as a mapping. It also makes it slightly more difficult  when it's needed to emit more than one event, such as https://github.com/deviceplug/btleplug/pull/114#discussion_r588820284