### PR TITLE
Reintroduce `cargo check --all-features` and `cargo check --no-default-features`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ path = "src/lib.rs"
 # crate-type = ["staticlib"]
 
 [features]
-serde = ["uuid/serde", "serde_cr"]
+serde = ["uuid/serde", "serde_cr", "serde_bytes"]
 
 [dependencies]
 log = "0.4.14"
@@ -29,6 +29,7 @@ bitflags = "1.2.1"
 thiserror = "1.0.23"
 uuid = "0.8.2"
 serde_cr = { package = "serde", version = "1.0.123", features = ["derive"], default-features = false, optional = true }
+serde_bytes = { version = "0.11.5", optional = true }
 dashmap = "4.0.2"
 futures = "0.3.12"
 static_assertions = "1.1.0"

--- a/build/default.yml
+++ b/build/default.yml
@@ -88,15 +88,10 @@ jobs:
        condition: eq(variables['Agent.OS'], 'Linux')
      - script: cargo check --all --bins --examples
        displayName: cargo check
-     # Can't do no features because we're in a workspace
-     #
-     # - script: cargo check --all --bins --examples --no-default-features
-     #   displayName: cargo check --no-default-features
-
-     # Can't do all features because we have platform specific features
-     #
-     # - script: cargo check --all --bins --examples --all-features
-     #   displayName: cargo check --all-features
+     - script: cargo check --all --bins --examples --no-default-features
+       displayName: cargo check --no-default-features
+     - script: cargo check --all --bins --examples --all-features
+       displayName: cargo check --all-features
      - script: cargo test --all
        displayName: cargo test
        # Set timeout for tests, as some tests seem to randomly stall.


### PR DESCRIPTION
the crate _serde_bytes_ is also added as it's needed for `Vec<u8>` and `Vec<Uuid>`