### PR TITLE
Add variant for errors from uuid crate

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -118,12 +118,6 @@ impl From<ParseBDAddrError> for Error {
     }
 }
 
-impl From<::uuid::Error> for Error {
-    fn from(error: ::uuid::Error) -> Self {
-        Error::Other(format!("Error parsing UUID: {}", error))
-    }
-}
-
 impl FromStr for BDAddr {
     type Err = ParseBDAddrError;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,6 +103,9 @@ pub enum Error {
     #[error("Timed out after {:?}", _0)]
     TimedOut(Duration),
 
+    #[error("Error parsing UUID: {0}")]
+    Uuid(#[from] uuid::Error),
+
     #[error("{}", _0)]
     Other(String),
 }


### PR DESCRIPTION
A crate should not hide its own error types by stringifying them.