### PR TITLE
Update to windows 0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,10 +46,10 @@ libc = "0.2.85"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 tokio = { version = "1.2", features = ["rt", "sync"] }
-windows = "0.4.0"
+windows = "0.6.0"
 
 [target.'cfg(target_os = "windows")'.build-dependencies]
-windows = "0.4.0"
+windows = "0.6.0"
 
 [dev-dependencies]
 simple_logger = "1.11.0"

--- a/src/winrtble/ble/characteristic.rs
+++ b/src/winrtble/ble/characteristic.rs
@@ -62,8 +62,12 @@ impl BLECharacteristic {
     }
 
     pub async fn read_value(&self) -> Result<Vec<u8>> {
-        let operation = self.characteristic.read_value_async().unwrap();
-        let result = operation.await.unwrap();
+        let result = self
+            .characteristic
+            .read_value_async()
+            .unwrap()
+            .await
+            .unwrap();
         if result.status().unwrap() == GattCommunicationStatus::Success {
             let value = result.value().unwrap();
             let reader = DataReader::from_buffer(&value).unwrap();
@@ -96,11 +100,12 @@ impl BLECharacteristic {
             self.notify_token = Some(token);
         }
         let config = GattClientCharacteristicConfigurationDescriptorValue::Notify;
-        let operation = self
+        let status = self
             .characteristic
             .write_client_characteristic_configuration_descriptor_async(config)
+            .unwrap()
+            .await
             .unwrap();
-        let status = operation.await.unwrap();
         trace!("subscribe {:?}", status);
         Ok(())
     }
@@ -111,11 +116,12 @@ impl BLECharacteristic {
         }
         self.notify_token = None;
         let config = GattClientCharacteristicConfigurationDescriptorValue::None;
-        let operation = self
+        let status = self
             .characteristic
             .write_client_characteristic_configuration_descriptor_async(config)
+            .unwrap()
+            .await
             .unwrap();
-        let status = operation.await.unwrap();
         trace!("unsubscribe {:?}", status);
         Ok(())
     }

--- a/src/winrtble/ble/device.rs
+++ b/src/winrtble/ble/device.rs
@@ -76,8 +76,7 @@ impl BLEDevice {
         &self,
         service: &GattDeviceService,
     ) -> std::result::Result<Vec<GattCharacteristic>, windows::Error> {
-        let operation = service.get_characteristics_async()?;
-        let async_result = operation.await?;
+        let async_result = service.get_characteristics_async()?.await?;
         let status = async_result.status();
         if status == Ok(GattCommunicationStatus::Success) {
             let results = async_result.characteristics()?;

--- a/src/winrtble/manager.rs
+++ b/src/winrtble/manager.rs
@@ -31,8 +31,7 @@ impl api::Manager for Manager {
 
     async fn adapters(&self) -> Result<Vec<Adapter>> {
         let mut result: Vec<Adapter> = vec![];
-        let operation = Radio::get_radios_async().unwrap();
-        let radios = operation.await.unwrap();
+        let radios = Radio::get_radios_async().unwrap().await.unwrap();
 
         for radio in &radios {
             let kind = radio.kind().unwrap();

--- a/src/winrtble/mod.rs
+++ b/src/winrtble/mod.rs
@@ -12,6 +12,7 @@
 // Copyright (c) 2014 The Rust Project Developers
 
 pub mod adapter;
+#[allow(dead_code)]
 mod bindings;
 mod ble;
 pub mod manager;


### PR DESCRIPTION
This fixes `windows::Error` to be `Send + Sync`, which allows the workarounds which were added for the async change before to be reverted.