### PR TITLE
chore: Remove unwraps in UWP characteristics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.7.2 (2021-04-04)
+
+## Bugfixes
+
+- Windows UWP characteristic methods now return errors instead of unwrapping everything.
+
 # 0.7.1 (2021-03-01)
 
 ## Bugfixes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "btleplug"
-version = "0.7.1"
+version = "0.7.2"
 authors = ["Nonpolynomial, LLC <kyle@nonpolynomial.com>"]
 license = "MIT/Apache-2.0/BSD-3-Clause"
 repository = "https://github.com/deviceplug/btleplug"


### PR DESCRIPTION
All of these methods now return std::Error, meaning we can just use the ? operator instead of panicking to pass the error up to the user.

Aiming this PR at master since async already came into dev. On r+, I'll update version/changelog and release 0.7.2, then will handle the dev branch rebase myself so we stay linear there.