### PR TITLE
Add custom de-/serialization for BDAddr

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,3 +55,4 @@ windows = "0.7.0"
 simple_logger = "1.11.0"
 rand = "0.8.3"
 tokio = { version = "1.2", features = ["macros", "rt", "rt-multi-thread"] }
+serde_json = "1.0"

--- a/src/api/bdaddr.rs
+++ b/src/api/bdaddr.rs
@@ -231,20 +231,20 @@ pub mod serde {
     /// # Example
     ///
     /// ```
-    /// //use btleplug::api::BDAddr;
-    /// //use serde::{Serialize, Deserialize};
-    /// //^^^ Error can't find crate `serde`???
-    /// //# use serde_cr as serde;
-    /// //
-    /// //#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
-    /// //struct S {
-    /// //    addr: BDAddr,
-    /// //}
-    /// //
-    /// //let s = serde_json::from_str(r#"{ "addr": "00:DE:AD:BE:EF:00" }"#)?;
-    /// //let expect = S { addr: [0x00, 0xDE, 0xAD, 0xBE, 0xEF, 0x00].into() };
-    /// //assert_eq!(s, expect);
-    /// //# Ok::<(), Box<dyn std::error::Error>>(())
+    /// # use serde_cr as serde;
+    /// use btleplug::api::BDAddr;
+    /// use serde::{Serialize, Deserialize};
+    ///
+    /// #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+    /// # #[serde(crate = "serde_cr")]
+    /// struct S {
+    ///     addr: BDAddr,
+    /// }
+    ///
+    /// let s: S = serde_json::from_str(r#"{ "addr": "00:DE:AD:BE:EF:00" }"#)?;
+    /// let expect = S { addr: [0x00, 0xDE, 0xAD, 0xBE, 0xEF, 0x00].into() };
+    /// assert_eq!(s, expect);
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub mod colon_delim {
         use super::*;
@@ -288,6 +288,26 @@ pub mod serde {
     }
 
     /// De-/Serialization of [`BDAddr`] as string of hex-digits without any delimiters.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use serde_cr as serde;
+    /// use btleplug::api::BDAddr;
+    /// use serde::{Serialize, Deserialize};
+    ///
+    /// #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+    /// # #[serde(crate = "serde_cr")]
+    /// struct S {
+    ///     #[serde(with = "btleplug::serde::bdaddr::no_delim")]
+    ///     addr: BDAddr,
+    /// }
+    ///
+    /// let s: S = serde_json::from_str(r#"{ "addr": "00deadbeef00" }"#)?;
+    /// let expect = S { addr: [0x00, 0xDE, 0xAD, 0xBE, 0xEF, 0x00].into() };
+    /// assert_eq!(s, expect);
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
     pub mod no_delim {
         use super::*;
 
@@ -331,6 +351,26 @@ pub mod serde {
     }
 
     /// De-/Serialization of [`BDAddr`] as an array of bytes.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use serde_cr as serde;
+    /// use btleplug::api::BDAddr;
+    /// use serde::{Serialize, Deserialize};
+    ///
+    /// #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+    /// # #[serde(crate = "serde_cr")]
+    /// struct S {
+    ///     #[serde(with = "btleplug::serde::bdaddr::bytes")]
+    ///     addr: BDAddr,
+    /// }
+    ///
+    /// let s: S = serde_json::from_str(r#"{ "addr": [ 0, 1, 2, 3, 4, 5] }"#)?;
+    /// let expect = S { addr: [0, 1, 2, 3, 4, 5].into() };
+    /// assert_eq!(s, expect);
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
     pub mod bytes {
         use super::*;
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -12,7 +12,7 @@
 // Copyright (c) 2014 The Rust Project Developers
 
 mod adapter_manager;
-mod bdaddr;
+pub(crate) mod bdaddr;
 pub mod bleuuid;
 
 pub use adapter_manager::AdapterManager;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,6 +101,8 @@ mod common;
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 mod corebluetooth;
 pub mod platform;
+#[cfg(feature = "serde")]
+pub mod serde;
 #[cfg(target_os = "windows")]
 mod winrtble;
 

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,0 +1,10 @@
+//! De-/Serialization with alternative formats.
+//!
+//! The various modules in here are intended to be used with `serde`'s [`with` annotation] to de-/serialize as something other than the default format.
+//!
+//! [`with` annotation]: https://serde.rs/attributes.html#field-attributes
+
+/// Different de-/serialization formats for [`crate::api::BDAddr`].
+pub mod bdaddr {
+    pub use crate::api::bdaddr::serde::*;
+}

--- a/src/winrtble/ble/characteristic.rs
+++ b/src/winrtble/ble/characteristic.rs
@@ -67,12 +67,7 @@ impl BLECharacteristic {
     }
 
     pub async fn read_value(&self) -> Result<Vec<u8>> {
-        let result = self
-            .characteristic
-            .ReadValueAsync()
-            .unwrap()
-            .await
-            .unwrap();
+        let result = self.characteristic.ReadValueAsync().unwrap().await.unwrap();
         if result.Status().unwrap() == GattCommunicationStatus::Success {
             let value = result.Value().unwrap();
             let reader = DataReader::FromBuffer(&value).unwrap();

--- a/src/winrtble/peripheral.rs
+++ b/src/winrtble/peripheral.rs
@@ -155,10 +155,7 @@ impl Peripheral {
         properties.address_type = AddressType::default();
         properties.has_scan_response =
             args.AdvertisementType().unwrap() == BluetoothLEAdvertisementType::ScanResponse;
-        properties.tx_power_level = args
-            .RawSignalStrengthInDBm()
-            .ok()
-            .map(|rssi| rssi as i8);
+        properties.tx_power_level = args.RawSignalStrengthInDBm().ok().map(|rssi| rssi as i8);
     }
 }
 


### PR DESCRIPTION
Like suggested in #68 this PR adds options to de-/serialize `BDAddr` in different formats.

If this get merged I could do a similar solution for the UUIDs.