### PR TITLE
Force  to read from GattCharacteristic from device instead of cache

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -17,6 +17,7 @@ fn main() {
         Windows::Devices::Bluetooth::{
             BluetoothConnectionStatus,
             BluetoothLEDevice,
+            BluetoothCacheMode,
         },
         Windows::Devices::Radios::{
             Radio,

--- a/src/winrtble/ble/characteristic.rs
+++ b/src/winrtble/ble/characteristic.rs
@@ -68,7 +68,13 @@ impl BLECharacteristic {
     }
 
     pub async fn read_value(&self) -> Result<Vec<u8>> {
-        let result = self.characteristic.ReadValueWithCacheModeAsync(BluetoothCacheMode(1)).unwrap().await.unwrap();
+        let result = self
+            .characteristic
+            // 1 = Ignore cache, 0 = Use windows cache
+            .ReadValueWithCacheModeAsync(BluetoothCacheMode(1))
+            .unwrap()
+            .await
+            .unwrap();
         if result.Status().unwrap() == GattCommunicationStatus::Success {
             let value = result.Value().unwrap();
             let reader = DataReader::FromBuffer(&value).unwrap();

--- a/src/winrtble/ble/characteristic.rs
+++ b/src/winrtble/ble/characteristic.rs
@@ -18,6 +18,7 @@ use crate::{
     Error, Result,
 };
 
+use bindings::Windows::Devices::Bluetooth::BluetoothCacheMode;
 use bindings::Windows::Devices::Bluetooth::GenericAttributeProfile::{
     GattCharacteristic, GattClientCharacteristicConfigurationDescriptorValue,
     GattCommunicationStatus, GattValueChangedEventArgs, GattWriteOption,
@@ -67,7 +68,7 @@ impl BLECharacteristic {
     }
 
     pub async fn read_value(&self) -> Result<Vec<u8>> {
-        let result = self.characteristic.ReadValueAsync().unwrap().await.unwrap();
+        let result = self.characteristic.ReadValueWithCacheModeAsync(BluetoothCacheMode(1)).unwrap().await.unwrap();
         if result.Status().unwrap() == GattCommunicationStatus::Success {
             let value = result.Value().unwrap();
             let reader = DataReader::FromBuffer(&value).unwrap();

--- a/src/winrtble/ble/characteristic.rs
+++ b/src/winrtble/ble/characteristic.rs
@@ -70,8 +70,7 @@ impl BLECharacteristic {
     pub async fn read_value(&self) -> Result<Vec<u8>> {
         let result = self
             .characteristic
-            // 1 = Ignore cache, 0 = Use windows cache
-            .ReadValueWithCacheModeAsync(BluetoothCacheMode(1))
+            .ReadValueWithCacheModeAsync(BluetoothCacheMode::Uncached)
             .unwrap()
             .await
             .unwrap();


### PR DESCRIPTION
Closes #155 

For some reason `BluetoothCacheMode(1)` is the no caching mode and `BluetoothCacheMode(0)` uses the cache. See [docs](https://docs.microsoft.com/en-us/uwp/api/windows.devices.bluetooth.bluetoothcachemode?view=winrt-19041#fields)

Using `BluetoothCacheMode::Uncached` did not work for me. Maybe this is not really an enum? My IDE was also not very helpful regarding these windows bindings.