### PR TITLE
Fix updating `Peripheral::characteristics` in `winrtble` (Windows) #170

### DIFF
--- a/src/winrtble/peripheral.rs
+++ b/src/winrtble/peripheral.rs
@@ -281,6 +281,9 @@ impl ApiPeripheral for Peripheral {
                     value_handle: 0,
                     properties,
                 };
+                let charas_mtx = Arc::clone(&self.characteristics);
+                let mut charas = charas_mtx.lock().unwrap();
+                charas.insert(chara.clone());
                 characteristics_result.push(chara);
                 self.ble_characteristics
                     .entry(uuid)


### PR DESCRIPTION
Update `Peripheral::characteristics` in `winrtble` when `discover_characteristics` called. You can get discovered characteristics correctly through `Peripheral::characteristics(&self)` by this workaround.