### PR TITLE
winrtble: report characteristic properties

### DIFF
--- a/src/winrtble/utils.rs
+++ b/src/winrtble/utils.rs
@@ -56,8 +56,39 @@ pub fn to_guid(uuid: &Uuid) -> Guid {
     Guid::from_values(data1, data2, data3, data4.to_owned())
 }
 
-pub fn to_char_props(_: &GattCharacteristicProperties) -> CharPropFlags {
-    CharPropFlags::from_bits_truncate(0 as u8)
+pub fn to_char_props(props: &GattCharacteristicProperties) -> CharPropFlags {
+    let mut flags = CharPropFlags::default();
+    if *props & GattCharacteristicProperties::Broadcast != GattCharacteristicProperties::None {
+        flags |= CharPropFlags::BROADCAST;
+    }
+    if *props & GattCharacteristicProperties::Read != GattCharacteristicProperties::None {
+        flags |= CharPropFlags::READ;
+    }
+    if *props & GattCharacteristicProperties::WriteWithoutResponse
+        != GattCharacteristicProperties::None
+    {
+        flags |= CharPropFlags::WRITE_WITHOUT_RESPONSE;
+    }
+    if *props & GattCharacteristicProperties::Write != GattCharacteristicProperties::None {
+        flags |= CharPropFlags::WRITE;
+    }
+    if *props & GattCharacteristicProperties::Notify != GattCharacteristicProperties::None {
+        flags |= CharPropFlags::NOTIFY;
+    }
+    if *props & GattCharacteristicProperties::Indicate != GattCharacteristicProperties::None {
+        flags |= CharPropFlags::INDICATE;
+    }
+    if *props & GattCharacteristicProperties::AuthenticatedSignedWrites
+        != GattCharacteristicProperties::None
+    {
+        flags |= CharPropFlags::AUTHENTICATED_SIGNED_WRITES;
+    }
+    if *props & GattCharacteristicProperties::ExtendedProperties
+        != GattCharacteristicProperties::None
+    {
+        flags |= CharPropFlags::EXTENDED_PROPERTIES;
+    }
+    flags
 }
 
 #[cfg(test)]


### PR DESCRIPTION
While experimenting with using btleplug on Windows with heart rate monitors where I was expecting to see characteristics with the notify property I noticed that no characteristics had any properties.

Poking around I saw that the `utils.rs::to_char_props()` utility hadn't been implemented yet and it was just returning blank flags.

After implementing this I can now see properties as expected.

As a side note: I noticed on Windows there are two additional properties documented here: https://docs.microsoft.com/en-us/uwp/api/windows.devices.bluetooth.genericattributeprofile.gattcharacteristicproperties?view=winrt-20348

`ReliableWrites` and `WritableAuxiliaries`

I wonder if `CharPropFlags` should be expanded to a u32 as on Windows and these properties could be reported too?