### PR TITLE
Remove CentralEvent::DeviceLost and rename CoreBluetoothEvent::DeviceLost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+## Breaking changes
+
+- Removed `CentralEvent::DeviceLost`. It wasn't emitted anywhere.
+
 # 0.8.1 (2021-08-14)
 
 ## Bugfixes

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -237,7 +237,6 @@ pub trait Peripheral: Send + Sync + Clone + Debug {
 #[derive(Debug, Clone)]
 pub enum CentralEvent {
     DeviceDiscovered(BDAddr),
-    DeviceLost(BDAddr),
     DeviceUpdated(BDAddr),
     DeviceConnected(BDAddr),
     DeviceDisconnected(BDAddr),

--- a/src/common/adapter_manager.rs
+++ b/src/common/adapter_manager.rs
@@ -55,9 +55,6 @@ where
             CentralEvent::DeviceDisconnected(addr) => {
                 self.shared.peripherals.remove(&addr);
             }
-            CentralEvent::DeviceLost(addr) => {
-                self.shared.peripherals.remove(&addr);
-            }
             _ => {}
         }
 

--- a/src/corebluetooth/adapter.rs
+++ b/src/corebluetooth/adapter.rs
@@ -71,7 +71,7 @@ impl Adapter {
                             manager_clone.emit(CentralEvent::DeviceUpdated(id));
                         }
                     }
-                    CoreBluetoothEvent::DeviceLost(uuid) => {
+                    CoreBluetoothEvent::DeviceDisconnected(uuid) => {
                         let id = uuid_to_bdaddr(&uuid.to_string());
                         manager_clone.emit(CentralEvent::DeviceDisconnected(id));
                     }

--- a/src/corebluetooth/internal.rs
+++ b/src/corebluetooth/internal.rs
@@ -264,7 +264,7 @@ pub enum CoreBluetoothEvent {
     DeviceDiscovered(Uuid, Option<String>, Receiver<CBPeripheralEvent>),
     DeviceUpdated(Uuid, String),
     // identifier
-    DeviceLost(Uuid),
+    DeviceDisconnected(Uuid),
 }
 
 impl CoreBluetoothInternal {
@@ -407,7 +407,7 @@ impl CoreBluetoothInternal {
     async fn on_peripheral_disconnect(&mut self, peripheral_uuid: Uuid) {
         trace!("Got disconnect event!");
         self.peripherals.remove(&peripheral_uuid);
-        self.dispatch_event(CoreBluetoothEvent::DeviceLost(peripheral_uuid))
+        self.dispatch_event(CoreBluetoothEvent::DeviceDisconnected(peripheral_uuid))
             .await;
     }
 


### PR DESCRIPTION
`CentralEvent::DeviceLost` was never constructed anywhere. `CoreBluetoothEvent::DeviceLost` actually corresponds to `CentralEvent::DeviceDisconnected`, so rename it to match.

Fixes #176.