### PR TITLE
Minor cleanups for CoreBluetooth implementation

### DIFF
--- a/src/common/adapter_manager.rs
+++ b/src/common/adapter_manager.rs
@@ -74,11 +74,6 @@ where
         }))
     }
 
-    #[allow(dead_code)]
-    pub fn has_peripheral(&self, addr: &BDAddr) -> bool {
-        self.shared.peripherals.contains_key(addr)
-    }
-
     pub fn add_peripheral(&self, addr: BDAddr, peripheral: PeripheralType) {
         assert!(
             !self.shared.peripherals.contains_key(&addr),

--- a/src/corebluetooth/adapter.rs
+++ b/src/corebluetooth/adapter.rs
@@ -70,7 +70,7 @@ impl Adapter {
                     }
                     CoreBluetoothEvent::DeviceUpdated { uuid, name } => {
                         let id = uuid_to_bdaddr(&uuid.to_string());
-                        if let Some(mut entry) = manager_clone.peripheral_mut(id) {
+                        if let Some(entry) = manager_clone.peripheral_mut(id) {
                             entry.value().update_name(&name);
                             manager_clone.emit(CentralEvent::DeviceUpdated(id));
                         }

--- a/src/corebluetooth/adapter.rs
+++ b/src/corebluetooth/adapter.rs
@@ -48,7 +48,11 @@ impl Adapter {
         task::spawn(async move {
             while let Some(msg) = receiver.next().await {
                 match msg {
-                    CoreBluetoothEvent::DeviceDiscovered(uuid, name, event_receiver) => {
+                    CoreBluetoothEvent::DeviceDiscovered {
+                        uuid,
+                        name,
+                        event_receiver,
+                    } => {
                         // TODO Gotta change uuid into a BDAddr for now. Expand
                         // library identifier type. :(
                         let id = uuid_to_bdaddr(&uuid.to_string());
@@ -64,14 +68,14 @@ impl Adapter {
                         );
                         manager_clone.emit(CentralEvent::DeviceDiscovered(id));
                     }
-                    CoreBluetoothEvent::DeviceUpdated(uuid, name) => {
+                    CoreBluetoothEvent::DeviceUpdated { uuid, name } => {
                         let id = uuid_to_bdaddr(&uuid.to_string());
                         if let Some(mut entry) = manager_clone.peripheral_mut(id) {
                             entry.value().update_name(&name);
                             manager_clone.emit(CentralEvent::DeviceUpdated(id));
                         }
                     }
-                    CoreBluetoothEvent::DeviceDisconnected(uuid) => {
+                    CoreBluetoothEvent::DeviceDisconnected { uuid } => {
                         let id = uuid_to_bdaddr(&uuid.to_string());
                         manager_clone.emit(CentralEvent::DeviceDisconnected(id));
                     }

--- a/src/corebluetooth/internal.rs
+++ b/src/corebluetooth/internal.rs
@@ -23,7 +23,7 @@ use futures::channel::mpsc::{self, Receiver, Sender};
 use futures::select;
 use futures::sink::SinkExt;
 use futures::stream::{Fuse, StreamExt};
-use log::{error, info, trace, warn};
+use log::{error, trace, warn};
 use objc::{
     rc::StrongPtr,
     runtime::{Object, YES},


### PR DESCRIPTION
Fix some warnings and name `CoreBluetoothEvent` enum variant fields.