### PR TITLE
Removes 'discovery_count' debug value

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -160,8 +160,6 @@ pub struct PeripheralProperties {
     pub service_data: HashMap<Uuid, Vec<u8>>,
     /// Advertised services for this device
     pub services: Vec<Uuid>,
-    /// Number of times we've seen advertising reports for this device
-    pub discovery_count: u32,
 }
 
 /// The type of write operation to use.

--- a/src/bluez/peripheral.rs
+++ b/src/bluez/peripheral.rs
@@ -72,7 +72,6 @@ impl api::Peripheral for Peripheral {
             manufacturer_data: device_info.manufacturer_data,
             service_data: device_info.service_data,
             services: device_info.services,
-            discovery_count: 0,
         }))
     }
 

--- a/src/corebluetooth/peripheral.rs
+++ b/src/corebluetooth/peripheral.rs
@@ -74,7 +74,6 @@ impl Peripheral {
             manufacturer_data: HashMap::new(),
             service_data: HashMap::new(),
             services: Vec::new(),
-            discovery_count: 1,
         });
         let (notifications_channel, _) = broadcast::channel(16);
 

--- a/src/winrtble/peripheral.rs
+++ b/src/winrtble/peripheral.rs
@@ -81,8 +81,6 @@ impl Peripheral {
         });
         let advertisement = args.Advertisement().unwrap();
 
-        properties.discovery_count += 1;
-
         // Advertisements are cumulative: set/replace data only if it's set
         if let Ok(name) = advertisement.LocalName() {
             if !name.is_empty() {


### PR DESCRIPTION
This discovery_count debug value was only maintained in the winrt
backend (it was a count of advertising packets received)

The documentation for the value didn't really reflect what the value was
and since it's not updated in the corebluetooth or bluez backends it's
not really something that can be depended on by applications.