### PR TITLE
chore: hide AdapterManager from public API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Removed `CentralEvent::DeviceLost`. It wasn't emitted anywhere.
 - Changed tx_power_level type from i8 to i16
+- Internal `AdapterManager` hidden from public API
 
 # 0.8.1 (2021-08-14)
 

--- a/src/common/adapter_manager.rs
+++ b/src/common/adapter_manager.rs
@@ -21,7 +21,7 @@ use tokio::sync::broadcast;
 use tokio_stream::wrappers::BroadcastStream;
 
 #[derive(Clone, Debug)]
-pub struct AdapterManager<PeripheralType>
+pub(crate) struct AdapterManager<PeripheralType>
 where
     PeripheralType: Peripheral,
 {


### PR DESCRIPTION
This marks the struct as pub(crate)

Resolves: #74