### PR TITLE
docs: notifications() stream valid across connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Features
 
 - Added Received Signal Strength Indicator (RSSI) peripheral property
+- Peripheral `notifications()` streams can now be queried before any
+  connection and remain valid independent of any re-connections.
 
 ## Breaking changes
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -224,8 +224,9 @@ pub trait Peripheral: Send + Sync + Clone + Debug {
     async fn unsubscribe(&self, characteristic: &Characteristic) -> Result<()>;
 
     /// Returns a stream of notifications for characteristic value updates. The stream will receive
-    /// a notification when a value notification or indication is received from the device. This
-    /// method should only be used after a connection has been established.
+    /// a notification when a value notification or indication is received from the device.
+    /// The stream will remain valid across connections and can be queried before any connection
+    /// is made.
     async fn notifications(&self) -> Result<Pin<Box<dyn Stream<Item = ValueNotification> + Send>>>;
 }
 


### PR DESCRIPTION
It's helpful for applications to know that they can query a
notifications stream for a Peripheral before opening any connection and
trust that the stream will remain valid across multiple re-connections
to the same Peripheral if necessary.

With the recent changes to use a broadcast channel in the winrt and
corebluetooth backends there's no longer anything special done with the
stream in relation to connections. In the bluez backend the only work
that's done is to register a device filter with dbus, which is also
independent of any connection state for the device.