### PR TITLE
Minor cleanups to example

### DIFF
--- a/examples/subscribe_notify_characteristic.rs
+++ b/examples/subscribe_notify_characteristic.rs
@@ -17,6 +17,8 @@ const NOTIFY_CHARACTERISTIC_UUID: Uuid = Uuid::from_u128(0x6e400002_b534_f393_67
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
+    pretty_env_logger::init();
+
     let manager = Manager::new().await?;
     let adapter_list = manager.adapters().await?;
     if adapter_list.is_empty() {

--- a/examples/subscribe_notify_characteristic.rs
+++ b/examples/subscribe_notify_characteristic.rs
@@ -89,10 +89,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                             }
                         }
                         println!("Disconnecting from peripheral {:?}...", local_name);
-                        peripheral
-                            .disconnect()
-                            .await
-                            .expect("Error disconnecting from BLE peripheral");
+                        peripheral.disconnect().await?;
                     }
                 } else {
                     println!("Skipping unknown peripheral {:?}", peripheral);

--- a/examples/subscribe_notify_characteristic.rs
+++ b/examples/subscribe_notify_characteristic.rs
@@ -64,9 +64,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
                         "Now connected ({:?}) to peripheral {:?}.",
                         is_connected, &local_name
                     );
-                    println!("Discover peripheral {:?} services...", local_name);
-                    peripheral.discover_services().await?;
                     if is_connected {
+                        println!("Discover peripheral {:?} services...", local_name);
+                        peripheral.discover_services().await?;
                         for characteristic in peripheral.characteristics() {
                             println!("Checking characteristic {:?}", characteristic);
                             // Subscribe to notifications from the characteristic with the selected

--- a/examples/subscribe_notify_characteristic.rs
+++ b/examples/subscribe_notify_characteristic.rs
@@ -76,7 +76,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
                             {
                                 println!("Subscribing to characteristic {:?}", characteristic.uuid);
                                 peripheral.subscribe(&characteristic).await?;
-                                let mut notification_stream = peripheral.notifications().await?;
+                                // Print the first 4 notifications received.
+                                let mut notification_stream =
+                                    peripheral.notifications().await?.take(4);
                                 // Process while the BLE connection is not broken or stopped.
                                 while let Some(data) = notification_stream.next().await {
                                     println!(


### PR DESCRIPTION
 * Add logging.
 * Limit the number of notifications printed.
 * Handle disconnection errors the same as other errors.
 * Only try to discover services if we connected.