### PR TITLE
winrtble: Cache is no longer used when requesting gatt services in `connect`

### DIFF
--- a/src/winrtble/peripheral.rs
+++ b/src/winrtble/peripheral.rs
@@ -370,6 +370,7 @@ impl ApiPeripheral for Peripheral {
         device.connect().await?;
         let mut d = self.shared.device.lock().await;
         *d = Some(device);
+        self.shared.connected.store(true, Ordering::Relaxed);
         self.shared
             .adapter
             .emit(CentralEvent::DeviceConnected(self.shared.address.into()));


### PR DESCRIPTION
`BLEDevice::connect` used a cache when requesting gatt services.
This means that a connection to the device might not be established if the services were previously cached.
Thus, a peripheral may not always be connected even if `Peripheral::connect` returns `Ok`.

After this change the gatt services are requested without the cache when connecting. `discover_services` may still use the cache.