### PR TITLE
Fix reference cycles in peripherals

### DIFF
--- a/src/corebluetooth/adapter.rs
+++ b/src/corebluetooth/adapter.rs
@@ -10,12 +10,13 @@ use futures::stream::{Stream, StreamExt};
 use log::*;
 use std::convert::{TryFrom, TryInto};
 use std::pin::Pin;
+use std::sync::Arc;
 use tokio::task;
 
 /// Implementation of [api::Central](crate::api::Central).
 #[derive(Clone, Debug)]
 pub struct Adapter {
-    manager: AdapterManager<Peripheral>,
+    manager: Arc<AdapterManager<Peripheral>>,
     sender: Sender<CoreBluetoothMessage>,
 }
 
@@ -36,7 +37,7 @@ impl Adapter {
             ));
         }
         debug!("Adapter connected");
-        let manager = AdapterManager::default();
+        let manager = Arc::new(AdapterManager::default());
 
         let manager_clone = manager.clone();
         let adapter_sender_clone = adapter_sender.clone();
@@ -51,7 +52,7 @@ impl Adapter {
                         manager_clone.add_peripheral(Peripheral::new(
                             uuid,
                             name,
-                            manager_clone.clone(),
+                            Arc::downgrade(&manager_clone),
                             event_receiver,
                             adapter_sender_clone.clone(),
                         ));

--- a/src/winrtble/adapter.rs
+++ b/src/winrtble/adapter.rs
@@ -28,13 +28,13 @@ use std::sync::{Arc, Mutex};
 #[derive(Clone)]
 pub struct Adapter {
     watcher: Arc<Mutex<BLEWatcher>>,
-    manager: AdapterManager<Peripheral>,
+    manager: Arc<AdapterManager<Peripheral>>,
 }
 
 impl Adapter {
     pub(crate) fn new() -> Self {
         let watcher = Arc::new(Mutex::new(BLEWatcher::new()));
-        let manager = AdapterManager::default();
+        let manager = Arc::new(AdapterManager::default());
         Adapter { watcher, manager }
     }
 }
@@ -65,7 +65,7 @@ impl Central for Adapter {
                 entry.value_mut().update_properties(args);
                 manager.emit(CentralEvent::DeviceUpdated(address.into()));
             } else {
-                let peripheral = Peripheral::new(manager.clone(), address);
+                let peripheral = Peripheral::new(Arc::downgrade(&manager), address);
                 peripheral.update_properties(args);
                 manager.add_peripheral(peripheral);
                 manager.emit(CentralEvent::DeviceDiscovered(address.into()));


### PR DESCRIPTION
AdapterManager and Peripherals had reference counted pointers to each other. This prevented them from ever getting disposed. If a connected peripheral is never disconnected manually, it would stay connected until the process is terminated.

There is now ever only a single instance of AdapterManager and peripherals have a weak reference to it.

Additionally, there was a reference cycle between Peripheral and BLEDevice in winrtble. ConnectedEventHandler in BLEDevice now uses a weak reference.