### PR TITLE
Add method to get adapter information for debug

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ dbus = "0.9.3"
 displaydoc = "0.2.3"
 parking_lot = "0.11.1"
 tokio = { version = "1.10.0", features = ["rt"] }
-bluez-async = "0.3.1"
+bluez-async = "0.5.0"
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 cocoa = "0.24.0"

--- a/examples/discover_adapters_peripherals.rs
+++ b/examples/discover_adapters_peripherals.rs
@@ -19,7 +19,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     }
 
     for adapter in adapter_list.iter() {
-        println!("Starting scan...");
+        println!("Starting scan on {}...", adapter.adapter_info().await?);
         adapter
             .start_scan(ScanFilter::default())
             .await

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -325,6 +325,12 @@ pub trait Central: Send + Sync + Clone {
 
     /// Add a [`Peripheral`] from a MAC address without a scan result. Not supported on all Bluetooth systems.
     async fn add_peripheral(&self, address: BDAddr) -> Result<Self::Peripheral>;
+
+    /// Get information about the Bluetooth adapter being used, such as the model or type.
+    ///
+    /// The details of this are platform-specific andyou should not attempt to parse it, but it may
+    /// be useful for debug logs.
+    async fn adapter_info(&self) -> Result<String>;
 }
 
 /// The Manager is the entry point to the library, providing access to all the Bluetooth adapters on

--- a/src/bluez/adapter.rs
+++ b/src/bluez/adapter.rs
@@ -120,7 +120,7 @@ async fn central_event(event: BluetoothEvent, session: BluetoothSession) -> Opti
         }
         BluetoothEvent::Device {
             id,
-            event: DeviceEvent::RSSI { rssi: _ },
+            event: DeviceEvent::Rssi { rssi: _ },
         } => {
             let device = session.get_device_info(&id).await.ok()?;
             Some(CentralEvent::DeviceUpdated((&device.mac_address).into()))

--- a/src/bluez/adapter.rs
+++ b/src/bluez/adapter.rs
@@ -88,6 +88,11 @@ impl Central for Adapter {
             "Can't add a Peripheral from a BDAddr".to_string(),
         ))
     }
+
+    async fn adapter_info(&self) -> Result<String> {
+        let adapter_info = self.session.get_adapter_info(&self.adapter).await?;
+        Ok(format!("{} ({})", adapter_info.id, adapter_info.modalias))
+    }
 }
 
 impl From<BluetoothError> for Error {

--- a/src/corebluetooth/adapter.rs
+++ b/src/corebluetooth/adapter.rs
@@ -117,4 +117,9 @@ impl Central for Adapter {
             "Can't add a Peripheral from a BDAddr".to_string(),
         ))
     }
+
+    async fn adapter_info(&self) -> Result<String> {
+        // TODO: Get information about the adapter.
+        Ok("CoreBluetooth".to_string())
+    }
 }

--- a/src/corebluetooth/adapter.rs
+++ b/src/corebluetooth/adapter.rs
@@ -8,7 +8,6 @@ use futures::channel::mpsc::{self, Sender};
 use futures::sink::SinkExt;
 use futures::stream::{Stream, StreamExt};
 use log::*;
-use std::convert::{TryFrom, TryInto};
 use std::pin::Pin;
 use std::sync::Arc;
 use tokio::task;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,6 +98,7 @@ use std::time::Duration;
 pub mod api;
 #[cfg(target_os = "linux")]
 mod bluez;
+#[cfg(not(target_os = "linux"))]
 mod common;
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 mod corebluetooth;

--- a/src/winrtble/adapter.rs
+++ b/src/winrtble/adapter.rs
@@ -93,4 +93,9 @@ impl Central for Adapter {
             "Can't add a Peripheral from a BDAddr".to_string(),
         ))
     }
+
+    async fn adapter_info(&self) -> Result<String> {
+        // TODO: Get information about the adapter.
+        Ok("WinRT".to_string())
+    }
 }


### PR DESCRIPTION
Implemented on Linux for now, other platforms have placeholders.

First step of #138.