### PR TITLE
Clean up PeripheralId on Linux

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ dbus = "0.9.5"
 displaydoc = "0.2.3"
 parking_lot = "0.11.2"
 tokio = { version = "1.14.0", features = ["rt"] }
-bluez-async = "0.5.4"
+bluez-async = "0.5.5"
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 cocoa = "0.24.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,9 +39,6 @@ tokio-stream = { version = "0.1.8", features = ["sync"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 dbus = "0.9.5"
-displaydoc = "0.2.3"
-parking_lot = "0.11.2"
-tokio = { version = "1.14.0", features = ["rt"] }
 bluez-async = "0.5.5"
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]

--- a/src/bluez/adapter.rs
+++ b/src/bluez/adapter.rs
@@ -42,7 +42,7 @@ impl Central for Adapter {
                 .flat_map(|device| {
                     let mut events = vec![CentralEvent::DeviceDiscovered(device.id.clone().into())];
                     if device.connected {
-                        events.push(CentralEvent::DeviceConnected(device.id.clone().into()));
+                        events.push(CentralEvent::DeviceConnected(device.id.into()));
                     }
                     events.into_iter()
                 }),

--- a/src/bluez/adapter.rs
+++ b/src/bluez/adapter.rs
@@ -40,10 +40,9 @@ impl Central for Adapter {
                 .into_iter()
                 .filter(move |device| device.id.adapter() == adapter_id)
                 .flat_map(|device| {
-                    let id: PeripheralId = device.mac_address.into();
-                    let mut events = vec![CentralEvent::DeviceDiscovered(id.clone())];
+                    let mut events = vec![CentralEvent::DeviceDiscovered(device.id.clone().into())];
                     if device.connected {
-                        events.push(CentralEvent::DeviceConnected(id));
+                        events.push(CentralEvent::DeviceConnected(device.id.clone().into()));
                     }
                     events.into_iter()
                 }),
@@ -89,7 +88,7 @@ impl Central for Adapter {
         devices
             .into_iter()
             .find_map(|device| {
-                if PeripheralId::from(device.mac_address) == *id {
+                if device.id == id.0 {
                     Some(Peripheral::new(self.session.clone(), device))
                 } else {
                     None
@@ -128,38 +127,38 @@ async fn central_event(
         } if id.adapter() == adapter_id => match device_event {
             DeviceEvent::Discovered => {
                 let device = session.get_device_info(&id).await.ok()?;
-                Some(CentralEvent::DeviceDiscovered(device.mac_address.into()))
+                Some(CentralEvent::DeviceDiscovered(device.id.into()))
             }
             DeviceEvent::Connected { connected } => {
                 let device = session.get_device_info(&id).await.ok()?;
                 if connected {
-                    Some(CentralEvent::DeviceConnected(device.mac_address.into()))
+                    Some(CentralEvent::DeviceConnected(device.id.into()))
                 } else {
-                    Some(CentralEvent::DeviceDisconnected(device.mac_address.into()))
+                    Some(CentralEvent::DeviceDisconnected(device.id.into()))
                 }
             }
             DeviceEvent::Rssi { rssi: _ } => {
                 let device = session.get_device_info(&id).await.ok()?;
-                Some(CentralEvent::DeviceUpdated(device.mac_address.into()))
+                Some(CentralEvent::DeviceUpdated(device.id.into()))
             }
             DeviceEvent::ManufacturerData { manufacturer_data } => {
                 let device = session.get_device_info(&id).await.ok()?;
                 Some(CentralEvent::ManufacturerDataAdvertisement {
-                    id: device.mac_address.into(),
+                    id: device.id.into(),
                     manufacturer_data,
                 })
             }
             DeviceEvent::ServiceData { service_data } => {
                 let device = session.get_device_info(&id).await.ok()?;
                 Some(CentralEvent::ServiceDataAdvertisement {
-                    id: device.mac_address.into(),
+                    id: device.id.into(),
                     service_data,
                 })
             }
             DeviceEvent::Services { services } => {
                 let device = session.get_device_info(&id).await.ok()?;
                 Some(CentralEvent::ServicesAdvertisement {
-                    id: device.mac_address.into(),
+                    id: device.id.into(),
                     services,
                 })
             }

--- a/src/bluez/adapter.rs
+++ b/src/bluez/adapter.rs
@@ -77,10 +77,9 @@ impl Central for Adapter {
     }
 
     async fn peripherals(&self) -> Result<Vec<Peripheral>> {
-        let devices = self.session.get_devices().await?;
+        let devices = self.session.get_devices_on_adapter(&self.adapter).await?;
         Ok(devices
             .into_iter()
-            .filter(|device| device.id.adapter() == self.adapter)
             .map(|device| Peripheral::new(self.session.clone(), device))
             .collect())
     }

--- a/src/bluez/peripheral.rs
+++ b/src/bluez/peripheral.rs
@@ -32,7 +32,7 @@ struct ServiceInternal {
     serde(crate = "serde_cr")
 )]
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct PeripheralId(BDAddr);
+pub struct PeripheralId(pub(crate) DeviceId);
 
 /// Implementation of [api::Peripheral](crate::api::Peripheral).
 #[derive(Clone, Debug)]
@@ -88,7 +88,7 @@ impl Peripheral {
 #[async_trait]
 impl api::Peripheral for Peripheral {
     fn id(&self) -> PeripheralId {
-        PeripheralId(self.address())
+        PeripheralId(self.device.to_owned())
     }
 
     fn address(&self) -> BDAddr {
@@ -245,9 +245,9 @@ impl From<MacAddress> for BDAddr {
     }
 }
 
-impl From<MacAddress> for PeripheralId {
-    fn from(mac_address: MacAddress) -> Self {
-        PeripheralId(mac_address.into())
+impl From<DeviceId> for PeripheralId {
+    fn from(device_id: DeviceId) -> Self {
+        PeripheralId(device_id)
     }
 }
 


### PR DESCRIPTION
Use `DeviceId` rather than MAC address as `PeripheralId` on Linux.

This is purely an internal cleanup with no API impact.