### PR TITLE
Made PeripheralId always be convertable from and to BDAddr

### DIFF
--- a/src/bluez/peripheral.rs
+++ b/src/bluez/peripheral.rs
@@ -251,6 +251,18 @@ impl From<&MacAddress> for PeripheralId {
     }
 }
 
+impl From<BDAddr> for PeripheralId {
+    fn from(address: BDAddr) -> Self {
+        PeripheralId(address)
+    }
+}
+
+impl Into<BDAddr> for PeripheralId {
+    fn into(self) -> BDAddr {
+        self.0
+    }
+}
+
 impl From<bluez_async::AddressType> for AddressType {
     fn from(address_type: bluez_async::AddressType) -> Self {
         match address_type {

--- a/src/corebluetooth/peripheral.rs
+++ b/src/corebluetooth/peripheral.rs
@@ -365,3 +365,16 @@ impl From<SendError> for Error {
         Error::Other("Channel closed".to_string().into())
     }
 }
+
+impl From<BDAddr> for PeripheralId {
+    fn from(address: BDAddr) -> Self {
+        PeripheralId(address)
+    }
+}
+
+impl Into<BDAddr> for PeripheralId {
+    fn into(self) -> BDAddr {
+        self.0
+    }
+}
+

--- a/src/corebluetooth/peripheral.rs
+++ b/src/corebluetooth/peripheral.rs
@@ -31,6 +31,7 @@ use serde_cr as serde;
 use std::sync::Weak;
 use std::{
     collections::{BTreeSet, HashMap},
+    convert::{TryFrom, TryInto},
     fmt::{self, Debug, Display, Formatter},
     pin::Pin,
     sync::{Arc, Mutex},
@@ -366,15 +367,24 @@ impl From<SendError> for Error {
     }
 }
 
-impl From<BDAddr> for PeripheralId {
-    fn from(address: BDAddr) -> Self {
-        PeripheralId(address)
+impl TryFrom<BDAddr> for PeripheralId {
+    type Error = crate::Error;
+
+    fn try_from(_: BDAddr) -> Result<Self> {
+        // TODO: Is there a way to convert from a BDAddr to a Uuid in osx?
+        Err(Error::InvalidBDAddr(
+            crate::ParseBDAddrError::IncorrectByteCount,
+        ))
     }
 }
 
-impl Into<BDAddr> for PeripheralId {
-    fn into(self) -> BDAddr {
-        self.0
+impl TryInto<BDAddr> for PeripheralId {
+    type Error = crate::Error;
+
+    fn try_into(self) -> Result<BDAddr> {
+        // TODO: Is there a way to convert from a Uuid to a BDAddr in osx?
+        Err(Error::InvalidBDAddr(
+            crate::ParseBDAddrError::IncorrectByteCount,
+        ))
     }
 }
-

--- a/src/winrtble/peripheral.rs
+++ b/src/winrtble/peripheral.rs
@@ -505,7 +505,7 @@ impl ApiPeripheral for Peripheral {
 
 impl From<BDAddr> for PeripheralId {
     fn from(address: BDAddr) -> Self {
-        PeripheralId(address)
+        Self(address)
     }
 }
 

--- a/src/winrtble/peripheral.rs
+++ b/src/winrtble/peripheral.rs
@@ -508,3 +508,9 @@ impl From<BDAddr> for PeripheralId {
         PeripheralId(address)
     }
 }
+
+impl Into<BDAddr> for PeripheralId {
+    fn into(self) -> BDAddr {
+        self.0
+    }
+}


### PR DESCRIPTION
On Windows, there is a conversion from `BDAddr` to `PeripheralId`. However there's no way to convert it back to a `BDAddr`. These conversions don't exist on linux or mac.

I'm making an abstraction layer for a bluetooth device that can run on both windows/linux/mac, as well as embedded. For this I have my own `PeripheralId` that I use internally. `btleplug` will handle the `std` implementation, and [rubble](https://docs.rs/rubble) will be the embedded implementation.

For this abstraction layer I need to convert my own `PeripheralId` type into btleplug's one. The best way I can see this happening is to have a conversion from/to:
- BDAddr
- [u8; 6]
- Something else?

The BDAddr conversion is already in place for Windows, so I figured I'd pick that route. Let me know if there's a different way that might make more sense.
