### PR TITLE
initial work on bluetooth from macos 12.x using filter

### DIFF
--- a/src/corebluetooth/framework.rs
+++ b/src/corebluetooth/framework.rs
@@ -70,9 +70,7 @@ pub mod ns {
     }
 
     pub fn string_to_cbuuid(s: *mut Object /* NSString */) -> *mut Object /* CBUUID */ {
-        unsafe {
-            msg_send![Class::get("CBUUID").unwrap(), UUIDWithString:s]
-        }
+        unsafe { msg_send![Class::get("CBUUID").unwrap(), UUIDWithString: s] }
     }
 
     // NSArray
@@ -85,14 +83,16 @@ pub mod ns {
         unsafe { msg_send![nsarray, objectAtIndex: index] }
     }
 
-    pub fn filter_nsarray(arr: Vec<String>) -> *mut Object /* NSArray */ {
-        let mut s = arr.iter().map(|a| {
-            string_to_cbuuid(str_to_nsstring(a))
-        }).collect::<Vec<*mut Object>>();
-        s.shrink_to_fit();
-        let len = s.len();
-        let ptr = s.as_mut_ptr();
-        unsafe { 
+    pub fn filter_nsarray(filters: Vec<String>) -> *mut Object /* NSArray */ {
+        let mut filter_cbuuids = filters
+            .iter()
+            .map(|a| string_to_cbuuid(str_to_nsstring(a)))
+            .collect::<Vec<*mut Object>>();
+        filter_cbuuids.shrink_to_fit();
+        let len = filter_cbuuids.len();
+        let ptr = filter_cbuuids.as_mut_ptr();
+
+        unsafe {
             let nsarray: *mut Object = msg_send![Class::get("NSArray").unwrap(), alloc];
             msg_send![nsarray, initWithObjects: ptr count: len]
         }
@@ -265,7 +265,9 @@ pub mod cb {
         filters: *mut Object, /* NSArray<UUID> */
         options: *mut Object, /* NSDictionary<NSString*,id> */
     ) {
-        unsafe { msg_send![cbcentralmanager, scanForPeripheralsWithServices:filters options:options] }
+        unsafe {
+            msg_send![cbcentralmanager, scanForPeripheralsWithServices:filters options:options]
+        }
     }
 
     pub fn centralmanager_stopscan(cbcentralmanager: *mut Object) {

--- a/src/corebluetooth/framework.rs
+++ b/src/corebluetooth/framework.rs
@@ -67,10 +67,6 @@ pub mod ns {
         unsafe { msg_send![nsstring, UTF8String] }
     }
 
-    pub fn string_to_cbuuid(s: *mut Object /* NSString */) -> *mut Object /* CBUUID */ {
-        unsafe { msg_send![Class::get("CBUUID").unwrap(), UUIDWithString: s] }
-    }
-
     // NSArray
 
     pub fn array_count(nsarray: *mut Object) -> c_uint {
@@ -447,6 +443,10 @@ pub mod cb {
 
     pub fn uuid_uuidstring(cbuuid: *mut Object) -> *mut Object /* NSString* */ {
         unsafe { msg_send![cbuuid, UUIDString] }
+    }
+
+    pub fn uuid_uuidwithstring(s: *mut Object /* NSString */) -> *mut Object /* CBUUID */ {
+        unsafe { msg_send![Class::get("CBUUID").unwrap(), UUIDWithString: s] }
     }
 
     // CBCentralManagerScanOption...Key

--- a/src/corebluetooth/framework.rs
+++ b/src/corebluetooth/framework.rs
@@ -16,12 +16,10 @@
 // This file may not be copied, modified, or distributed except
 // according to those terms.
 
+use cocoa::foundation::NSUInteger;
 use objc::runtime::{Class, Object, BOOL};
 use objc::{msg_send, sel, sel_impl};
 use std::os::raw::{c_char, c_int, c_uint};
-
-//TODO: cargo check told me to do this but I feel like it's not right.
-use crate::corebluetooth::utils::nsstring::str_to_nsstring;
 
 #[allow(non_upper_case_globals)]
 pub const nil: *mut Object = 0 as *mut Object;
@@ -83,18 +81,13 @@ pub mod ns {
         unsafe { msg_send![nsarray, objectAtIndex: index] }
     }
 
-    pub fn filter_nsarray(filters: Vec<String>) -> *mut Object /* NSArray */ {
-        let mut filter_cbuuids = filters
-            .iter()
-            .map(|a| string_to_cbuuid(str_to_nsstring(a)))
-            .collect::<Vec<*mut Object>>();
-        filter_cbuuids.shrink_to_fit();
-        let len = filter_cbuuids.len();
-        let ptr = filter_cbuuids.as_mut_ptr();
-
+    pub fn arraywithobjects_count(objects: *const *mut Object, count: NSUInteger) -> *mut Object {
         unsafe {
-            let nsarray: *mut Object = msg_send![Class::get("NSArray").unwrap(), alloc];
-            msg_send![nsarray, initWithObjects: ptr count: len]
+            msg_send![
+                Class::get("NSArray").unwrap(),
+                arrayWithObjects: objects
+                count: count
+            ]
         }
     }
 
@@ -260,13 +253,13 @@ pub mod cb {
         }
     }
 
-    pub fn centralmanager_scanforperipherals_options(
+    pub fn centralmanager_scanforperipheralswithservices_options(
         cbcentralmanager: *mut Object,
-        filters: *mut Object, /* NSArray<UUID> */
-        options: *mut Object, /* NSDictionary<NSString*,id> */
+        service_uuids: *mut Object, /* NSArray<CBUUID *> */
+        options: *mut Object,       /* NSDictionary<NSString*,id> */
     ) {
         unsafe {
-            msg_send![cbcentralmanager, scanForPeripheralsWithServices:filters options:options]
+            msg_send![cbcentralmanager, scanForPeripheralsWithServices:service_uuids options:options]
         }
     }
 

--- a/src/corebluetooth/framework.rs
+++ b/src/corebluetooth/framework.rs
@@ -20,6 +20,7 @@ use objc::runtime::{Class, Object, BOOL};
 use objc::{msg_send, sel, sel_impl};
 use std::os::raw::{c_char, c_int, c_uint};
 
+//TODO: cargo check told me to do this but I feel like it's not right.
 use crate::corebluetooth::utils::nsstring::str_to_nsstring;
 
 #[allow(non_upper_case_globals)]
@@ -69,7 +70,6 @@ pub mod ns {
     }
 
     pub fn string_to_cbuuid(s: *mut Object /* NSString */) -> *mut Object /* CBUUID */ {
-        println!("s to cbuuid: {:?}", s);
         unsafe {
             msg_send![Class::get("CBUUID").unwrap(), UUIDWithString:s]
         }
@@ -85,7 +85,7 @@ pub mod ns {
         unsafe { msg_send![nsarray, objectAtIndex: index] }
     }
 
-    pub fn init_with_array(arr: Vec<String>) -> *mut Object /* NSArray */ {
+    pub fn filter_nsarray(arr: Vec<String>) -> *mut Object /* NSArray */ {
         let mut s = arr.iter().map(|a| {
             string_to_cbuuid(str_to_nsstring(a))
         }).collect::<Vec<*mut Object>>();

--- a/src/corebluetooth/internal.rs
+++ b/src/corebluetooth/internal.rs
@@ -807,6 +807,7 @@ impl CoreBluetoothInternal {
             cb::CENTRALMANAGERSCANOPTIONALLOWDUPLICATESKEY
         });
         // TODO: set cb::CBCENTRALMANAGERSCANOPTIONSOLICITEDSERVICEUUIDSKEY with filter.services
+        // TODO: behavoir when filter.services is empty? call with nil services?
         cb::centralmanager_scanforperipherals_options(*self.manager, services, options);
     }
 

--- a/src/corebluetooth/internal.rs
+++ b/src/corebluetooth/internal.rs
@@ -795,16 +795,20 @@ impl CoreBluetoothInternal {
         }
     }
 
-    fn start_discovery(&mut self, _filter: ScanFilter) {
+    fn start_discovery(&mut self, filter: ScanFilter) {
         trace!("BluetoothAdapter::start_discovery");
         let options = ns::mutabledictionary();
         // NOTE: If duplicates are not allowed then a peripheral will not show
         // up again once connected and then disconnected.
+
+        //TODO: translation to string? Or a better type?
+        let fstrings = filter.services.into_iter().map(|s| s.to_string()).collect();
+        let services = ns::init_with_array(fstrings);
         ns::mutabledictionary_setobject_forkey(options, ns::number_withbool(YES), unsafe {
             cb::CENTRALMANAGERSCANOPTIONALLOWDUPLICATESKEY
         });
         // TODO: set cb::CBCENTRALMANAGERSCANOPTIONSOLICITEDSERVICEUUIDSKEY with filter.services
-        cb::centralmanager_scanforperipherals_options(*self.manager, options);
+        cb::centralmanager_scanforperipherals_options(*self.manager, services, options);
     }
 
     fn stop_discovery(&mut self) {

--- a/src/corebluetooth/internal.rs
+++ b/src/corebluetooth/internal.rs
@@ -797,13 +797,12 @@ impl CoreBluetoothInternal {
 
     fn start_discovery(&mut self, filter: ScanFilter) {
         trace!("BluetoothAdapter::start_discovery");
-        let options = ns::mutabledictionary();
-        // NOTE: If duplicates are not allowed then a peripheral will not show
-        // up again once connected and then disconnected.
-
         //TODO: translation to string? Or a better type?
         let fstrings = filter.services.into_iter().map(|s| s.to_string()).collect();
         let services = ns::filter_nsarray(fstrings);
+        let options = ns::mutabledictionary();
+        // NOTE: If duplicates are not allowed then a peripheral will not show
+        // up again once connected and then disconnected.
         ns::mutabledictionary_setobject_forkey(options, ns::number_withbool(YES), unsafe {
             cb::CENTRALMANAGERSCANOPTIONALLOWDUPLICATESKEY
         });

--- a/src/corebluetooth/internal.rs
+++ b/src/corebluetooth/internal.rs
@@ -803,7 +803,7 @@ impl CoreBluetoothInternal {
 
         //TODO: translation to string? Or a better type?
         let fstrings = filter.services.into_iter().map(|s| s.to_string()).collect();
-        let services = ns::init_with_array(fstrings);
+        let services = ns::filter_nsarray(fstrings);
         ns::mutabledictionary_setobject_forkey(options, ns::number_withbool(YES), unsafe {
             cb::CENTRALMANAGERSCANOPTIONALLOWDUPLICATESKEY
         });

--- a/src/corebluetooth/utils/core_bluetooth.rs
+++ b/src/corebluetooth/utils/core_bluetooth.rs
@@ -20,7 +20,7 @@ use objc::runtime::Object;
 use uuid::Uuid;
 
 use super::super::framework::{cb, nil, ns};
-use super::nsstring::nsstring_to_string;
+use super::nsstring::{nsstring_to_string, str_to_nsstring};
 
 /// Convert a CBUUID object to the standard Uuid type.
 pub fn cbuuid_to_uuid(cbuuid: *mut Object) -> Uuid {
@@ -37,6 +37,11 @@ pub fn cbuuid_to_uuid(cbuuid: *mut Object) -> Uuid {
     };
     let uuid_string = long.to_lowercase();
     uuid_string.parse().unwrap()
+}
+
+/// Convert a `Uuid` to a `CBUUID`.
+pub fn uuid_to_cbuuid(uuid: Uuid) -> *mut Object {
+    ns::string_to_cbuuid(str_to_nsstring(&uuid.to_string()))
 }
 
 pub fn peripheral_debug(peripheral: *mut Object) -> String {
@@ -99,5 +104,16 @@ mod tests {
             uuid,
             Uuid::from_u128(0x12345678_0000_1111_2222_333344445555)
         );
+    }
+
+    #[test]
+    fn cbuuid_roundtrip() {
+        for uuid in [
+            Uuid::from_u128(0x00001234_0000_1000_8000_00805f9b34fb),
+            Uuid::from_u128(0xabcd1234_0000_1000_8000_00805f9b34fb),
+            Uuid::from_u128(0x12345678_0000_1111_2222_333344445555),
+        ] {
+            assert_eq!(cbuuid_to_uuid(uuid_to_cbuuid(uuid)), uuid);
+        }
     }
 }

--- a/src/corebluetooth/utils/core_bluetooth.rs
+++ b/src/corebluetooth/utils/core_bluetooth.rs
@@ -41,7 +41,7 @@ pub fn cbuuid_to_uuid(cbuuid: *mut Object) -> Uuid {
 
 /// Convert a `Uuid` to a `CBUUID`.
 pub fn uuid_to_cbuuid(uuid: Uuid) -> *mut Object {
-    ns::string_to_cbuuid(str_to_nsstring(&uuid.to_string()))
+    cb::uuid_uuidwithstring(str_to_nsstring(&uuid.to_string()))
 }
 
 pub fn peripheral_debug(peripheral: *mut Object) -> String {


### PR DESCRIPTION
Initial work on a solution for #224 

Hi,
I'd like to preface this by stating I'm super new to bluetooth, objective-c ffi, rust, and open source. So I'm about as in over my head as it gets. But I had a test environment for this bug and a desire to fix it, so here we are. I figured even if this doesn't end up being a good patch, it's a good test. I've tested this against [this gist](https://gist.github.com/subtle-supernova/495e9f0931b132751f85d2c109486fed) which scan for sennheiser devices and therefor pickup my headphones. My test returned a device id `00:00:00:00:00:00` with the connected bool as `false`, but I'm unsure if that's related to any of the changes I've made here.

Please let me know if there's anything else I can do, and thank you for the library. 