### PR TITLE
In docs use events() instead of event_receiver().

### DIFF
--- a/examples/event_driven_discovery.rs
+++ b/examples/event_driven_discovery.rs
@@ -21,15 +21,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // connect to the adapter
     let central = get_central(&manager).await;
 
-    // Each adapter can only have one event receiver. We fetch it via
-    // event_receiver(), which will return an option. The first time the getter
-    // is called, it will return Some(Receiver<CentralEvent>). After that, it
-    // will only return None.
-    //
-    // While this API is awkward, is is done as not to disrupt the adapter
-    // retrieval system in btleplug v0.x while still allowing us to use event
-    // streams/channels instead of callbacks. In btleplug v1.x, we'll retrieve
-    // channels as part of adapter construction.
+    // Each adapter has an event stream, we fetch via events(),
+    // simplifying the type, this will return what is essentially a
+    // Future<Result<Stream<Item=CentralEvent>>>.
     let mut events = central.events().await?;
 
     // start scanning for devices

--- a/examples/lights.rs
+++ b/examples/lights.rs
@@ -46,8 +46,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     // start scanning for devices
     central.start_scan(ScanFilter::default()).await?;
-    // instead of waiting, you can use central.event_receiver() to get a channel
-    // to listen for notifications on.
+    // instead of waiting, you can use central.events() to get a stream which will
+    // notify you of new devices, for an example of that see examples/event_driven_discovery.rs
     time::sleep(Duration::from_secs(2)).await;
 
     // find the device we're interested in

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,8 +41,8 @@
 //!
 //!     // start scanning for devices
 //!     central.start_scan(ScanFilter::default()).await?;
-//!     // instead of waiting, you can use central.event_receiver() to fetch a channel and
-//!     // be notified of new devices
+//!     // instead of waiting, you can use central.events() to get a stream which will
+//!     // notify you of new devices, for an example of that see examples/event_driven_discovery.rs
 //!     time::sleep(Duration::from_secs(2)).await;
 //!
 //!     // find the device we're interested in

--- a/src/winrtble/ble/characteristic.rs
+++ b/src/winrtble/ble/characteristic.rs
@@ -18,17 +18,19 @@ use crate::{
     Error, Result,
 };
 
-use windows::{
-    Devices::Bluetooth::{BluetoothCacheMode, GenericAttributeProfile::{
-        GattCharacteristic,
-        GattClientCharacteristicConfigurationDescriptorValue, GattCommunicationStatus,
-        GattValueChangedEventArgs, GattWriteOption,
-    }},  
-    Foundation::{EventRegistrationToken, TypedEventHandler},
-    Storage::Streams::{DataReader, DataWriter}
-};
 use log::{debug, trace};
 use uuid::Uuid;
+use windows::{
+    Devices::Bluetooth::{
+        BluetoothCacheMode,
+        GenericAttributeProfile::{
+            GattCharacteristic, GattClientCharacteristicConfigurationDescriptorValue,
+            GattCommunicationStatus, GattValueChangedEventArgs, GattWriteOption,
+        },
+    },
+    Foundation::{EventRegistrationToken, TypedEventHandler},
+    Storage::Streams::{DataReader, DataWriter},
+};
 
 pub type NotifiyEventHandler = Box<dyn Fn(Vec<u8>) + Send>;
 

--- a/src/winrtble/ble/device.rs
+++ b/src/winrtble/ble/device.rs
@@ -12,14 +12,17 @@
 // Copyright (c) 2014 The Rust Project Developers
 
 use crate::{api::BDAddr, winrtble::utils, Error, Result};
-use windows::{Devices::Bluetooth::{GenericAttributeProfile::{
-    GattCharacteristic, GattCommunicationStatus, GattDeviceService, GattDeviceServicesResult,
-    },
-    BluetoothCacheMode, BluetoothConnectionStatus, BluetoothLEDevice,
-    },
-    Foundation::{EventRegistrationToken, TypedEventHandler}
-};
 use log::{debug, trace};
+use windows::{
+    Devices::Bluetooth::{
+        BluetoothCacheMode, BluetoothConnectionStatus, BluetoothLEDevice,
+        GenericAttributeProfile::{
+            GattCharacteristic, GattCommunicationStatus, GattDeviceService,
+            GattDeviceServicesResult,
+        },
+    },
+    Foundation::{EventRegistrationToken, TypedEventHandler},
+};
 
 pub type ConnectedEventHandler = Box<dyn Fn(bool) + Send>;
 

--- a/src/winrtble/manager.rs
+++ b/src/winrtble/manager.rs
@@ -14,7 +14,7 @@
 use super::adapter::Adapter;
 use crate::{api, Result};
 use async_trait::async_trait;
-use windows::Devices::{Radios::{Radio, RadioKind}};
+use windows::Devices::Radios::{Radio, RadioKind};
 
 /// Implementation of [api::Manager](crate::api::Manager).
 #[derive(Clone, Debug)]

--- a/src/winrtble/peripheral.rs
+++ b/src/winrtble/peripheral.rs
@@ -12,8 +12,8 @@
 // Copyright (c) 2014 The Rust Project Developers
 
 use super::{
-    advertisement_data_type, ble::characteristic::BLECharacteristic,
-    ble::device::BLEDevice, ble::service::BLEService, utils,
+    advertisement_data_type, ble::characteristic::BLECharacteristic, ble::device::BLEDevice,
+    ble::service::BLEService, utils,
 };
 use crate::{
     api::{
@@ -43,8 +43,8 @@ use std::{
 use tokio::sync::broadcast;
 use uuid::Uuid;
 
-use windows::Devices::Bluetooth::{Advertisement::*, BluetoothAddressType};
 use std::sync::Weak;
+use windows::Devices::Bluetooth::{Advertisement::*, BluetoothAddressType};
 
 #[cfg_attr(
     feature = "serde",

--- a/src/winrtble/utils.rs
+++ b/src/winrtble/utils.rs
@@ -12,15 +12,16 @@
 // Copyright (c) 2014 The Rust Project Developers
 
 use crate::{api::CharPropFlags, Error, Result};
-use windows::{
-    Devices::Bluetooth::GenericAttributeProfile::{
-        GattCharacteristicProperties, GattCommunicationStatus, GattClientCharacteristicConfigurationDescriptorValue
-    },
-    Storage::Streams::{DataReader, IBuffer},
-};
 use std::str::FromStr;
 use uuid::Uuid;
 use windows::core::GUID;
+use windows::{
+    Devices::Bluetooth::GenericAttributeProfile::{
+        GattCharacteristicProperties, GattClientCharacteristicConfigurationDescriptorValue,
+        GattCommunicationStatus,
+    },
+    Storage::Streams::{DataReader, IBuffer},
+};
 
 pub fn to_error(status: GattCommunicationStatus) -> Result<()> {
     if status == GattCommunicationStatus::AccessDenied {
@@ -36,7 +37,9 @@ pub fn to_error(status: GattCommunicationStatus) -> Result<()> {
     }
 }
 
-pub fn to_descriptor_value(properties: GattCharacteristicProperties) -> GattClientCharacteristicConfigurationDescriptorValue {
+pub fn to_descriptor_value(
+    properties: GattCharacteristicProperties,
+) -> GattClientCharacteristicConfigurationDescriptorValue {
     let notify = GattCharacteristicProperties::Notify;
     let indicate = GattCharacteristicProperties::Indicate;
     if properties & indicate == indicate {


### PR DESCRIPTION
Minor thing that AFAICT `events_receiver()` is gone, in favor of `events()`.
This patch just updates places in docs and examples where `events_receiver()` was referred to.