### PR TITLE
use select!, stream_map in event_driven_discovery.

### DIFF
--- a/examples/event_driven_discovery.rs
+++ b/examples/event_driven_discovery.rs
@@ -1,15 +1,12 @@
 // See the "macOS permissions note" in README.md before running this on macOS
 // Big Sur or later.
 
-use btleplug::api::{bleuuid::BleUuid, Central, CentralEvent, Manager as _, ScanFilter};
-use btleplug::platform::{Adapter, Manager};
+use btleplug::api::{
+    bleuuid::BleUuid, Central, CentralEvent, Manager as _, Peripheral as _, ScanFilter,
+};
+use btleplug::platform::Manager;
 use futures::stream::StreamExt;
 use std::error::Error;
-
-async fn get_central(manager: &Manager) -> Adapter {
-    let adapters = manager.adapters().await.unwrap();
-    adapters.into_iter().nth(0).unwrap()
-}
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
@@ -17,51 +14,70 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let manager = Manager::new().await?;
 
-    // get the first bluetooth adapter
-    // connect to the adapter
-    let central = get_central(&manager).await;
-
-    // Each adapter has an event stream, we fetch via events(),
-    // simplifying the type, this will return what is essentially a
-    // Future<Result<Stream<Item=CentralEvent>>>.
-    let mut events = central.events().await?;
+    let adapters = manager.adapters().await?;
 
     // start scanning for devices
-    central.start_scan(ScanFilter::default()).await?;
+    for adapter in &adapters {
+        adapter.start_scan(ScanFilter::default()).await?;
+    }
+
+    let mut stream_map = tokio_stream::StreamMap::new();
+    // Turn adapters into something like:
+    // vec![(0, adaptors[0].events().await?), ...].iter()
+    //
+    // Insert these into a StreamMap
+    // For the key we use the index into adapters.
+    // The value is the event stream.
+    //
+    for (idx, evt_stream) in adapters
+        .iter()
+        .enumerate()
+        .map(|(idx, adapter)| (idx, adapter.events()))
+    {
+        stream_map.insert(idx, evt_stream.await?);
+    }
 
     // Print based on whatever the event receiver outputs. Note that the event
     // receiver blocks, so in a real program, this should be run in its own
     // thread (not task, as this library does not yet use async channels).
-    while let Some(event) = events.next().await {
-        match event {
-            CentralEvent::DeviceDiscovered(id) => {
-                println!("DeviceDiscovered: {:?}", id);
-            }
-            CentralEvent::DeviceConnected(id) => {
-                println!("DeviceConnected: {:?}", id);
-            }
-            CentralEvent::DeviceDisconnected(id) => {
-                println!("DeviceDisconnected: {:?}", id);
-            }
-            CentralEvent::ManufacturerDataAdvertisement {
-                id,
-                manufacturer_data,
-            } => {
-                println!(
-                    "ManufacturerDataAdvertisement: {:?}, {:?}",
-                    id, manufacturer_data
-                );
-            }
-            CentralEvent::ServiceDataAdvertisement { id, service_data } => {
-                println!("ServiceDataAdvertisement: {:?}, {:?}", id, service_data);
-            }
-            CentralEvent::ServicesAdvertisement { id, services } => {
-                let services: Vec<String> =
-                    services.into_iter().map(|s| s.to_short_string()).collect();
-                println!("ServicesAdvertisement: {:?}, {:?}", id, services);
-            }
-            _ => {}
+    loop {
+        tokio::select! {
+           idx_event_opt = stream_map.next() => {
+              if let Some((adapter_idx, event)) = idx_event_opt {
+                 match event {
+                        CentralEvent::DeviceDiscovered(id) => {
+                            // Example of getting the perepheral for the id.
+                            let peripheral = adapters[adapter_idx].peripheral(&id).await?;
+                            assert!(id == peripheral.id());
+                            println!("DeviceDiscovered: {:?}", id);
+                        }
+                        CentralEvent::DeviceConnected(id) => {
+                            println!("DeviceConnected: {:?}", id);
+                        }
+                        CentralEvent::DeviceDisconnected(id) => {
+                            println!("DeviceDisconnected: {:?}", id);
+                        }
+                        CentralEvent::ManufacturerDataAdvertisement {
+                            id,
+                            manufacturer_data,
+                        } => {
+                            println!(
+                                "ManufacturerDataAdvertisement: {:?}, {:?}",
+                                id, manufacturer_data
+                            );
+                        }
+                        CentralEvent::ServiceDataAdvertisement { id, service_data } => {
+                            println!("ServiceDataAdvertisement: {:?}, {:?}", id, service_data);
+                        }
+                        CentralEvent::ServicesAdvertisement { id, services } => {
+                            let services: Vec<String> =
+                                services.into_iter().map(|s| s.to_short_string()).collect();
+                            println!("ServicesAdvertisement: {:?}, {:?}", id, services);
+                        }
+                        _ => {}
+                 }
+              }
+           }
         }
     }
-    Ok(())
 }


### PR DESCRIPTION
This uses StreamMap to make the event_driven_discovery example work with multiple adaptors,
and uses tokio::select! instead of the while loop.

I also added an assertion to show how to get a peripheral from the identifier.
Feel free to close this however, if you think it is getting into territory beyond that fit for examples.