### PR TITLE
Clean up CoreBluetooth code and use more wrappers from cocoa crate

### DIFF
--- a/src/corebluetooth/central_delegate.rs
+++ b/src/corebluetooth/central_delegate.rs
@@ -28,6 +28,7 @@ use futures::sink::SinkExt;
 use libc::{c_char, c_void};
 use log::{error, trace};
 use objc::{
+    class,
     declare::ClassDecl,
     rc::StrongPtr,
     runtime::{Class, Object, Protocol, Sel},
@@ -244,11 +245,7 @@ pub mod CentralDelegate {
     fn delegate_class() -> &'static Class {
         trace!("delegate_class");
         static REGISTER_DELEGATE_CLASS: Once = Once::new();
-        let mut decl = ClassDecl::new(
-            "BtlePlugCentralManagerDelegate",
-            Class::get("NSObject").unwrap(),
-        )
-        .unwrap();
+        let mut decl = ClassDecl::new("BtlePlugCentralManagerDelegate", class!(NSObject)).unwrap();
 
         REGISTER_DELEGATE_CLASS.call_once(|| {
             decl.add_protocol(Protocol::get("CBCentralManagerDelegate").unwrap());
@@ -296,7 +293,7 @@ pub mod CentralDelegate {
             decl.register();
         });
 
-        Class::get("BtlePlugCentralManagerDelegate").unwrap()
+        class!(BtlePlugCentralManagerDelegate)
     }
 
     fn localized_description(error: *mut Object) -> String {

--- a/src/corebluetooth/central_delegate.rs
+++ b/src/corebluetooth/central_delegate.rs
@@ -17,13 +17,13 @@
 // according to those terms.
 
 use super::{
-    framework::{cb, nil, ns},
+    framework::{cb, ns},
     utils::{
         core_bluetooth::{cbuuid_to_uuid, characteristic_debug, peripheral_debug, service_debug},
         nsdata_to_vec, nsuuid_to_uuid,
     },
 };
-use cocoa::base::id;
+use cocoa::base::{id, nil};
 use futures::channel::mpsc::{self, Receiver, Sender};
 use futures::sink::SinkExt;
 use libc::{c_char, c_void};

--- a/src/corebluetooth/central_delegate.rs
+++ b/src/corebluetooth/central_delegate.rs
@@ -23,6 +23,7 @@ use super::{
         nsdata_to_vec, nsuuid_to_uuid,
     },
 };
+use cocoa::base::id;
 use futures::channel::mpsc::{self, Receiver, Sender};
 use futures::sink::SinkExt;
 use libc::{c_char, c_void};
@@ -219,11 +220,11 @@ pub mod CentralDelegate {
 
     use super::*;
 
-    pub fn delegate() -> (*mut Object, Receiver<CentralDelegateEvent>) {
+    pub fn delegate() -> (id, Receiver<CentralDelegateEvent>) {
         let (sender, receiver) = mpsc::channel::<CentralDelegateEvent>(256);
         let sendbox = Box::new(sender);
         let delegate = unsafe {
-            let mut delegate: *mut Object = msg_send![delegate_class(), alloc];
+            let mut delegate: id = msg_send![delegate_class(), alloc];
             delegate = msg_send![
                 delegate,
                 initWithSender: Box::into_raw(sendbox) as *mut c_void
@@ -233,7 +234,7 @@ pub mod CentralDelegate {
         (delegate, receiver)
     }
 
-    pub fn delegate_drop_channel(delegate: *mut Object) {
+    pub fn delegate_drop_channel(delegate: id) {
         unsafe {
             let _ = Box::from_raw(*(&*delegate).get_ivar::<*mut c_void>(DELEGATE_SENDER_IVAR)
                 as *mut Sender<CentralDelegateEvent>);
@@ -254,40 +255,40 @@ pub mod CentralDelegate {
             unsafe {
                 // Initialization
                 decl.add_method(sel!(initWithSender:),
-                                delegate_init as extern fn(&mut Object, Sel, *mut c_void) -> *mut Object);
+                                delegate_init as extern fn(&mut Object, Sel, *mut c_void) -> id);
 
                 // CentralManager Events
                 decl.add_method(sel!(centralManagerDidUpdateState:),
-                                delegate_centralmanagerdidupdatestate as extern fn(&mut Object, Sel, *mut Object));
+                                delegate_centralmanagerdidupdatestate as extern fn(&mut Object, Sel, id));
                 // decl.add_method(sel!(centralManager:willRestoreState:),
-                //                 delegate_centralmanager_willrestorestate as extern fn(&mut Object, Sel, *mut Object, *mut Object));
+                //                 delegate_centralmanager_willrestorestate as extern fn(&mut Object, Sel, id, id));
                 decl.add_method(sel!(centralManager:didConnectPeripheral:),
-                                delegate_centralmanager_didconnectperipheral as extern fn(&mut Object, Sel, *mut Object, *mut Object));
+                                delegate_centralmanager_didconnectperipheral as extern fn(&mut Object, Sel, id, id));
                 decl.add_method(sel!(centralManager:didDisconnectPeripheral:error:),
-                                delegate_centralmanager_diddisconnectperipheral_error as extern fn(&mut Object, Sel, *mut Object, *mut Object, *mut Object));
+                                delegate_centralmanager_diddisconnectperipheral_error as extern fn(&mut Object, Sel, id, id, id));
                 // decl.add_method(sel!(centralManager:didFailToConnectPeripheral:error:),
-                //                 delegate_centralmanager_didfailtoconnectperipheral_error as extern fn(&mut Object, Sel, *mut Object, *mut Object, *mut Object));
+                //                 delegate_centralmanager_didfailtoconnectperipheral_error as extern fn(&mut Object, Sel, id, id, id));
                 decl.add_method(sel!(centralManager:didDiscoverPeripheral:advertisementData:RSSI:),
-                                delegate_centralmanager_diddiscoverperipheral_advertisementdata_rssi as extern fn(&mut Object, Sel, *mut Object, *mut Object, *mut Object, *mut Object));
+                                delegate_centralmanager_diddiscoverperipheral_advertisementdata_rssi as extern fn(&mut Object, Sel, id, id, id, id));
 
                 // Peripheral events
                 decl.add_method(sel!(peripheral:didDiscoverServices:),
-                                delegate_peripheral_diddiscoverservices as extern fn(&mut Object, Sel, *mut Object, *mut Object));
+                                delegate_peripheral_diddiscoverservices as extern fn(&mut Object, Sel, id, id));
                 decl.add_method(sel!(peripheral:didDiscoverIncludedServicesForService:error:),
-                                delegate_peripheral_diddiscoverincludedservicesforservice_error as extern fn(&mut Object, Sel, *mut Object, *mut Object, *mut Object));
+                                delegate_peripheral_diddiscoverincludedservicesforservice_error as extern fn(&mut Object, Sel, id, id, id));
                 decl.add_method(sel!(peripheral:didDiscoverCharacteristicsForService:error:),
-                                delegate_peripheral_diddiscovercharacteristicsforservice_error as extern fn(&mut Object, Sel, *mut Object, *mut Object, *mut Object));
+                                delegate_peripheral_diddiscovercharacteristicsforservice_error as extern fn(&mut Object, Sel, id, id, id));
                 // TODO Finish implementing this.
                 // decl.add_method(sel!(peripheral:didDiscoverDescriptorsForCharacteristic:error:),
-                //                 delegate_peripheral_diddiscoverdescriptorsforcharacteristic_error as extern fn(&mut Object, Sel, *mut Object, *mut Object, *mut Object));
+                //                 delegate_peripheral_diddiscoverdescriptorsforcharacteristic_error as extern fn(&mut Object, Sel, id, id, id));
                 decl.add_method(sel!(peripheral:didUpdateValueForCharacteristic:error:),
-                                delegate_peripheral_didupdatevalueforcharacteristic_error as extern fn(&mut Object, Sel, *mut Object, *mut Object, *mut Object));
+                                delegate_peripheral_didupdatevalueforcharacteristic_error as extern fn(&mut Object, Sel, id, id, id));
                 decl.add_method(sel!(peripheral:didUpdateNotificationStateForCharacteristic:error:),
-                                delegate_peripheral_didupdatenotificationstateforcharacteristic_error as extern fn(&mut Object, Sel, *mut Object, *mut Object, *mut Object));
+                                delegate_peripheral_didupdatenotificationstateforcharacteristic_error as extern fn(&mut Object, Sel, id, id, id));
                 decl.add_method(sel!(peripheral:didWriteValueForCharacteristic:error:),
-                                delegate_peripheral_didwritevalueforcharacteristic_error as extern fn(&mut Object, Sel, *mut Object, *mut Object, *mut Object));
+                                delegate_peripheral_didwritevalueforcharacteristic_error as extern fn(&mut Object, Sel, id, id, id));
                 decl.add_method(sel!(peripheral:didReadRSSI:error:),
-                                delegate_peripheral_didreadrssi_error as extern fn(&mut Object, Sel, *mut Object, *mut Object, *mut Object));
+                                delegate_peripheral_didreadrssi_error as extern fn(&mut Object, Sel, id, id, id));
             }
 
             decl.register();
@@ -296,12 +297,12 @@ pub mod CentralDelegate {
         class!(BtlePlugCentralManagerDelegate)
     }
 
-    fn localized_description(error: *mut Object) -> String {
+    fn localized_description(error: id) -> String {
         if error == nil {
             "".to_string()
         } else {
             unsafe {
-                let nsstring: *mut Object = msg_send![error, localizedDescription];
+                let nsstring: id = msg_send![error, localizedDescription];
                 let c_string: *const c_char = msg_send![nsstring, UTF8String];
                 let c_str: &CStr = CStr::from_ptr(c_string);
                 let str_slice: &str = c_str.to_str().unwrap();
@@ -333,11 +334,7 @@ pub mod CentralDelegate {
         });
     }
 
-    extern "C" fn delegate_init(
-        delegate: &mut Object,
-        _cmd: Sel,
-        sender: *mut c_void,
-    ) -> *mut Object {
+    extern "C" fn delegate_init(delegate: &mut Object, _cmd: Sel, sender: *mut c_void) -> id {
         trace!("delegate_init");
         // TODO Should these maybe be Option<T>, so we can denote when we've
         // dropped? Not quite sure how delegate lifetime works here.
@@ -348,7 +345,7 @@ pub mod CentralDelegate {
         delegate
     }
 
-    fn get_characteristic_value(characteristic: *mut Object) -> Vec<u8> {
+    fn get_characteristic_value(characteristic: id) -> Vec<u8> {
         trace!("Getting data!");
         let value = cb::characteristic_value(characteristic);
         let v = nsdata_to_vec(value);
@@ -365,21 +362,21 @@ pub mod CentralDelegate {
     extern "C" fn delegate_centralmanagerdidupdatestate(
         delegate: &mut Object,
         _cmd: Sel,
-        _central: *mut Object,
+        _central: id,
     ) {
         trace!("delegate_centralmanagerdidupdatestate");
         send_delegate_event(delegate, CentralDelegateEvent::DidUpdateState);
     }
 
-    // extern fn delegate_centralmanager_willrestorestate(_delegate: &mut Object, _cmd: Sel, _central: *mut Object, _dict: *mut Object) {
+    // extern fn delegate_centralmanager_willrestorestate(_delegate: &mut Object, _cmd: Sel, _central: id, _dict: id) {
     //     trace!("delegate_centralmanager_willrestorestate");
     // }
 
     extern "C" fn delegate_centralmanager_didconnectperipheral(
         delegate: &mut Object,
         _cmd: Sel,
-        _central: *mut Object,
-        peripheral: *mut Object,
+        _central: id,
+        peripheral: id,
     ) {
         trace!(
             "delegate_centralmanager_didconnectperipheral {}",
@@ -397,9 +394,9 @@ pub mod CentralDelegate {
     extern "C" fn delegate_centralmanager_diddisconnectperipheral_error(
         delegate: &mut Object,
         _cmd: Sel,
-        _central: *mut Object,
-        peripheral: *mut Object,
-        _error: *mut Object,
+        _central: id,
+        peripheral: id,
+        _error: id,
     ) {
         trace!(
             "delegate_centralmanager_diddisconnectperipheral_error {}",
@@ -412,17 +409,17 @@ pub mod CentralDelegate {
         );
     }
 
-    // extern fn delegate_centralmanager_didfailtoconnectperipheral_error(_delegate: &mut Object, _cmd: Sel, _central: *mut Object, _peripheral: *mut Object, _error: *mut Object) {
+    // extern fn delegate_centralmanager_didfailtoconnectperipheral_error(_delegate: &mut Object, _cmd: Sel, _central: id, _peripheral: id, _error: id) {
     //     trace!("delegate_centralmanager_didfailtoconnectperipheral_error");
     // }
 
     extern "C" fn delegate_centralmanager_diddiscoverperipheral_advertisementdata_rssi(
         delegate: &mut Object,
         _cmd: Sel,
-        _central: *mut Object,
-        peripheral: *mut Object,
-        adv_data: *mut Object,
-        _rssi: *mut Object,
+        _central: id,
+        peripheral: id,
+        adv_data: id,
+        _rssi: id,
     ) {
         trace!(
             "delegate_centralmanager_diddiscoverperipheral_advertisementdata_rssi {}",
@@ -513,8 +510,8 @@ pub mod CentralDelegate {
     extern "C" fn delegate_peripheral_diddiscoverservices(
         delegate: &mut Object,
         _cmd: Sel,
-        peripheral: *mut Object,
-        error: *mut Object,
+        peripheral: id,
+        error: id,
     ) {
         trace!(
             "delegate_peripheral_diddiscoverservices {} {}",
@@ -554,9 +551,9 @@ pub mod CentralDelegate {
     extern "C" fn delegate_peripheral_diddiscoverincludedservicesforservice_error(
         _delegate: &mut Object,
         _cmd: Sel,
-        peripheral: *mut Object,
-        service: *mut Object,
-        error: *mut Object,
+        peripheral: id,
+        service: id,
+        error: id,
     ) {
         trace!(
             "delegate_peripheral_diddiscoverincludedservicesforservice_error {} {} {}",
@@ -576,9 +573,9 @@ pub mod CentralDelegate {
     extern "C" fn delegate_peripheral_diddiscovercharacteristicsforservice_error(
         delegate: &mut Object,
         _cmd: Sel,
-        peripheral: *mut Object,
-        service: *mut Object,
-        error: *mut Object,
+        peripheral: id,
+        service: id,
+        error: id,
     ) {
         trace!(
             "delegate_peripheral_diddiscovercharacteristicsforservice_error {} {} {}",
@@ -614,9 +611,9 @@ pub mod CentralDelegate {
     extern "C" fn delegate_peripheral_didupdatevalueforcharacteristic_error(
         delegate: &mut Object,
         _cmd: Sel,
-        peripheral: *mut Object,
-        characteristic: *mut Object,
-        error: *mut Object,
+        peripheral: id,
+        characteristic: id,
+        error: id,
     ) {
         trace!(
             "delegate_peripheral_didupdatevalueforcharacteristic_error {} {} {}",
@@ -642,9 +639,9 @@ pub mod CentralDelegate {
     extern "C" fn delegate_peripheral_didwritevalueforcharacteristic_error(
         delegate: &mut Object,
         _cmd: Sel,
-        peripheral: *mut Object,
-        characteristic: *mut Object,
-        error: *mut Object,
+        peripheral: id,
+        characteristic: id,
+        error: id,
     ) {
         trace!(
             "delegate_peripheral_didwritevalueforcharacteristic_error {} {} {}",
@@ -668,9 +665,9 @@ pub mod CentralDelegate {
     extern "C" fn delegate_peripheral_didupdatenotificationstateforcharacteristic_error(
         delegate: &mut Object,
         _cmd: Sel,
-        peripheral: *mut Object,
-        characteristic: *mut Object,
-        _error: *mut Object,
+        peripheral: id,
+        characteristic: id,
+        _error: id,
     ) {
         trace!("delegate_peripheral_didupdatenotificationstateforcharacteristic_error");
         // TODO check for error here
@@ -699,24 +696,24 @@ pub mod CentralDelegate {
         }
     }
 
-    // extern fn delegate_peripheral_diddiscoverdescriptorsforcharacteristic_error(_delegate: &mut Object, _cmd: Sel, _peripheral: *mut Object, _characteristic: *mut Object, _error: *mut Object) {
+    // extern fn delegate_peripheral_diddiscoverdescriptorsforcharacteristic_error(_delegate: &mut Object, _cmd: Sel, _peripheral: id, _characteristic: id, _error: id) {
     //     info!("delegate_peripheral_diddiscoverdescriptorsforcharacteristic_error");
     // }
 
-    // extern fn delegate_peripheral_didupdatevaluefordescriptor(_delegate: &mut Object, _cmd: Sel, _peripheral: *mut Object, _descriptor: *mut Object, _error: *mut Object) {
+    // extern fn delegate_peripheral_didupdatevaluefordescriptor(_delegate: &mut Object, _cmd: Sel, _peripheral: id, _descriptor: id, _error: id) {
     //     trace!("delegate_peripheral_didupdatevaluefordescriptor");
     // }
 
-    // extern fn delegate_peripheral_didwritevaluefordescriptor_error(_delegate: &mut Object, _cmd: Sel, _peripheral: *mut Object, _descriptor: *mut Object, _error: *mut Object) {
+    // extern fn delegate_peripheral_didwritevaluefordescriptor_error(_delegate: &mut Object, _cmd: Sel, _peripheral: id, _descriptor: id, _error: id) {
     //     trace!("delegate_peripheral_didwritevaluefordescriptor_error");
     // }
 
     extern "C" fn delegate_peripheral_didreadrssi_error(
         _delegate: &mut Object,
         _cmd: Sel,
-        peripheral: *mut Object,
-        _rssi: *mut Object,
-        error: *mut Object,
+        peripheral: id,
+        _rssi: id,
+        error: id,
     ) {
         trace!(
             "delegate_peripheral_didreadrssi_error {}",

--- a/src/corebluetooth/framework.rs
+++ b/src/corebluetooth/framework.rs
@@ -16,44 +16,44 @@
 // This file may not be copied, modified, or distributed except
 // according to those terms.
 
-use cocoa::foundation::NSUInteger;
-use objc::runtime::{Object, BOOL};
+use cocoa::{base::id, foundation::NSUInteger};
+use objc::runtime::BOOL;
 use objc::{class, msg_send, sel, sel_impl};
 use std::os::raw::{c_char, c_int, c_uint};
 
 #[allow(non_upper_case_globals)]
-pub const nil: *mut Object = 0 as *mut Object;
+pub const nil: id = 0 as id;
 
 pub mod ns {
     use super::*;
 
     // NSNumber
 
-    pub fn number_withbool(value: BOOL) -> *mut Object {
+    pub fn number_withbool(value: BOOL) -> id {
         unsafe { msg_send![class!(NSNumber), numberWithBool: value] }
     }
 
     // NSString
 
-    pub fn string(cstring: *const c_char) -> *mut Object /* NSString* */ {
+    pub fn string(cstring: *const c_char) -> id /* NSString* */ {
         unsafe { msg_send![class!(NSString), stringWithUTF8String: cstring] }
     }
 
-    pub fn string_utf8string(nsstring: *mut Object) -> *const c_char {
+    pub fn string_utf8string(nsstring: id) -> *const c_char {
         unsafe { msg_send![nsstring, UTF8String] }
     }
 
     // NSArray
 
-    pub fn array_count(nsarray: *mut Object) -> c_uint {
+    pub fn array_count(nsarray: id) -> c_uint {
         unsafe { msg_send![nsarray, count] }
     }
 
-    pub fn array_objectatindex(nsarray: *mut Object, index: c_uint) -> *mut Object {
+    pub fn array_objectatindex(nsarray: id, index: c_uint) -> id {
         unsafe { msg_send![nsarray, objectAtIndex: index] }
     }
 
-    pub fn arraywithobjects_count(objects: *const *mut Object, count: NSUInteger) -> *mut Object {
+    pub fn arraywithobjects_count(objects: *const id, count: NSUInteger) -> id {
         unsafe {
             msg_send![
                 class!(NSArray),
@@ -65,47 +65,43 @@ pub mod ns {
 
     // NSDictionary
 
-    pub fn dictionary_allkeys(nsdict: *mut Object) -> *mut Object /* NSArray* */ {
+    pub fn dictionary_allkeys(nsdict: id) -> id /* NSArray* */ {
         unsafe { msg_send![nsdict, allKeys] }
     }
 
-    pub fn dictionary_objectforkey(nsdict: *mut Object, key: *mut Object) -> *mut Object {
+    pub fn dictionary_objectforkey(nsdict: id, key: id) -> id {
         unsafe { msg_send![nsdict, objectForKey: key] }
     }
 
     // NSMutableDictionary : NSDictionary
 
-    pub fn mutabledictionary() -> *mut Object {
+    pub fn mutabledictionary() -> id {
         unsafe { msg_send![class!(NSMutableDictionary), dictionaryWithCapacity:0] }
     }
 
-    pub fn mutabledictionary_setobject_forkey(
-        nsmutdict: *mut Object,
-        object: *mut Object,
-        key: *mut Object,
-    ) {
+    pub fn mutabledictionary_setobject_forkey(nsmutdict: id, object: id, key: id) {
         unsafe { msg_send![nsmutdict, setObject:object forKey:key] }
     }
 
     // NSData
 
-    pub fn data(bytes: *const u8, length: c_uint) -> *mut Object /* NSData* */ {
+    pub fn data(bytes: *const u8, length: c_uint) -> id /* NSData* */ {
         unsafe { msg_send![class!(NSData), dataWithBytes:bytes length:length] }
     }
 
-    pub fn data_length(nsdata: *mut Object) -> c_uint {
+    pub fn data_length(nsdata: id) -> c_uint {
         unsafe { msg_send![nsdata, length] }
     }
 
-    pub fn data_bytes(nsdata: *mut Object) -> *const u8 {
+    pub fn data_bytes(nsdata: id) -> *const u8 {
         unsafe { msg_send![nsdata, bytes] }
     }
 
     // NSUUID
 
-    pub fn uuid_uuidstring(nsuuid: *mut Object) -> *mut Object /* NSString* */ {
+    pub fn uuid_uuidstring(nsuuid: id) -> id /* NSString* */ {
         unsafe {
-            let uuidstring: *mut Object = msg_send![nsuuid, UUIDString];
+            let uuidstring: id = msg_send![nsuuid, UUIDString];
             uuidstring
         }
     }
@@ -138,21 +134,21 @@ pub mod cb {
 
         #[link(name = "CoreBluetooth", kind = "framework")]
         extern "C" {
-            pub static CBAdvertisementDataManufacturerDataKey: *mut Object;
-            pub static CBAdvertisementDataServiceDataKey: *mut Object;
-            pub static CBAdvertisementDataServiceUUIDsKey: *mut Object;
+            pub static CBAdvertisementDataManufacturerDataKey: id;
+            pub static CBAdvertisementDataServiceDataKey: id;
+            pub static CBAdvertisementDataServiceUUIDsKey: id;
 
-            pub static CBCentralManagerScanOptionAllowDuplicatesKey: *mut Object;
+            pub static CBCentralManagerScanOptionAllowDuplicatesKey: id;
         }
     }
 
     // CBCentralManager
 
-    pub fn centralmanager(delegate: *mut Object, /*CBCentralManagerDelegate* */) -> *mut Object /*CBCentralManager* */
+    pub fn centralmanager(delegate: id /*CBCentralManagerDelegate* */) -> id /*CBCentralManager* */
     {
         let label = CString::new("CBqueue").unwrap();
         unsafe {
-            let cbcentralmanager: *mut Object = msg_send![class!(CBCentralManager), alloc];
+            let cbcentralmanager: id = msg_send![class!(CBCentralManager), alloc];
             let queue = dispatch_queue_create(label.as_ptr(), DISPATCH_QUEUE_SERIAL);
 
             msg_send![cbcentralmanager, initWithDelegate:delegate queue:queue]
@@ -160,29 +156,29 @@ pub mod cb {
     }
 
     pub fn centralmanager_scanforperipheralswithservices_options(
-        cbcentralmanager: *mut Object,
-        service_uuids: *mut Object, /* NSArray<CBUUID *> */
-        options: *mut Object,       /* NSDictionary<NSString*,id> */
+        cbcentralmanager: id,
+        service_uuids: id, /* NSArray<CBUUID *> */
+        options: id,       /* NSDictionary<NSString*,id> */
     ) {
         unsafe {
             msg_send![cbcentralmanager, scanForPeripheralsWithServices:service_uuids options:options]
         }
     }
 
-    pub fn centralmanager_stopscan(cbcentralmanager: *mut Object) {
+    pub fn centralmanager_stopscan(cbcentralmanager: id) {
         unsafe { msg_send![cbcentralmanager, stopScan] }
     }
 
     pub fn centralmanager_connectperipheral(
-        cbcentralmanager: *mut Object,
-        peripheral: *mut Object, /* CBPeripheral* */
+        cbcentralmanager: id,
+        peripheral: id, /* CBPeripheral* */
     ) {
         unsafe { msg_send![cbcentralmanager, connectPeripheral:peripheral options:nil] }
     }
 
     pub fn centralmanager_cancelperipheralconnection(
-        cbcentralmanager: *mut Object,
-        peripheral: *mut Object, /* CBPeripheral* */
+        cbcentralmanager: id,
+        peripheral: id, /* CBPeripheral* */
     ) {
         unsafe { msg_send![cbcentralmanager, cancelPeripheralConnection: peripheral] }
     }
@@ -203,13 +199,13 @@ pub mod cb {
 
     // CBPeer
 
-    pub fn peer_identifier(cbpeer: *mut Object) -> *mut Object /* NSUUID* */ {
+    pub fn peer_identifier(cbpeer: id) -> id /* NSUUID* */ {
         unsafe { msg_send![cbpeer, identifier] }
     }
 
     // CBPeripheral : CBPeer
 
-    pub fn peripheral_name(cbperipheral: *mut Object) -> *mut Object /* NSString* */ {
+    pub fn peripheral_name(cbperipheral: id) -> id /* NSString* */ {
         unsafe { msg_send![cbperipheral, name] }
     }
 
@@ -222,51 +218,47 @@ pub mod cb {
         Disconnecting = 3,
     }
 
-    pub fn peripheral_state(cbperipheral: *mut Object) -> CBPeripheralState {
+    pub fn peripheral_state(cbperipheral: id) -> CBPeripheralState {
         unsafe { msg_send![cbperipheral, state] }
     }
 
-    pub fn peripheral_setdelegate(
-        cbperipheral: *mut Object,
-        delegate: *mut Object, /* CBPeripheralDelegate* */
-    ) {
+    pub fn peripheral_setdelegate(cbperipheral: id, delegate: id /* CBPeripheralDelegate* */) {
         unsafe { msg_send![cbperipheral, setDelegate: delegate] }
     }
 
-    pub fn peripheral_discoverservices(cbperipheral: *mut Object) {
+    pub fn peripheral_discoverservices(cbperipheral: id) {
         unsafe { msg_send![cbperipheral, discoverServices: nil] }
     }
 
     pub fn peripheral_discoverincludedservicesforservice(
-        cbperipheral: *mut Object,
-        service: *mut Object, /* CBService* */
+        cbperipheral: id,
+        service: id, /* CBService* */
     ) {
         unsafe { msg_send![cbperipheral, discoverIncludedServices:nil forService:service] }
     }
 
-    pub fn peripheral_services(cbperipheral: *mut Object) -> *mut Object /* NSArray<CBService*>* */
-    {
+    pub fn peripheral_services(cbperipheral: id) -> id /* NSArray<CBService*>* */ {
         unsafe { msg_send![cbperipheral, services] }
     }
 
     pub fn peripheral_discovercharacteristicsforservice(
-        cbperipheral: *mut Object,
-        service: *mut Object, /* CBService* */
+        cbperipheral: id,
+        service: id, /* CBService* */
     ) {
         unsafe { msg_send![cbperipheral, discoverCharacteristics:nil forService:service] }
     }
 
     pub fn peripheral_readvalue_forcharacteristic(
-        cbperipheral: *mut Object,
-        characteristic: *mut Object, /* CBCharacteristic* */
+        cbperipheral: id,
+        characteristic: id, /* CBCharacteristic* */
     ) {
         unsafe { msg_send![cbperipheral, readValueForCharacteristic: characteristic] }
     }
 
     pub fn peripheral_writevalue_forcharacteristic(
-        cbperipheral: *mut Object,
-        value: *mut Object,          /* NSData* */
-        characteristic: *mut Object, /* CBCharacteristic* */
+        cbperipheral: id,
+        value: id,          /* NSData* */
+        characteristic: id, /* CBCharacteristic* */
         write_type: usize,
     ) {
         unsafe {
@@ -276,16 +268,16 @@ pub mod cb {
     }
 
     pub fn peripheral_setnotifyvalue_forcharacteristic(
-        cbperipheral: *mut Object,
+        cbperipheral: id,
         value: BOOL,
-        characteristic: *mut Object, /* CBCharacteristic* */
+        characteristic: id, /* CBCharacteristic* */
     ) {
         unsafe { msg_send![cbperipheral, setNotifyValue:value forCharacteristic:characteristic] }
     }
 
     pub fn peripheral_discoverdescriptorsforcharacteristic(
-        cbperipheral: *mut Object,
-        characteristic: *mut Object, /* CBCharacteristic* */
+        cbperipheral: id,
+        characteristic: id, /* CBCharacteristic* */
     ) {
         unsafe {
             msg_send![
@@ -301,41 +293,39 @@ pub mod cb {
 
     // CBAttribute
 
-    pub fn attribute_uuid(cbattribute: *mut Object) -> *mut Object /* CBUUID* */ {
+    pub fn attribute_uuid(cbattribute: id) -> id /* CBUUID* */ {
         unsafe { msg_send![cbattribute, UUID] }
     }
 
     // CBService : CBAttribute
 
-    pub fn service_isprimary(cbservice: *mut Object) -> BOOL {
+    pub fn service_isprimary(cbservice: id) -> BOOL {
         unsafe { msg_send![cbservice, isPrimary] }
     }
 
-    pub fn service_includedservices(cbservice: *mut Object) -> *mut Object /* NSArray<CBService*>* */
-    {
+    pub fn service_includedservices(cbservice: id) -> id /* NSArray<CBService*>* */ {
         unsafe { msg_send![cbservice, includedServices] }
     }
 
-    pub fn service_characteristics(cbservice: *mut Object) -> *mut Object /* NSArray<CBCharacteristic*>* */
-    {
+    pub fn service_characteristics(cbservice: id) -> id /* NSArray<CBCharacteristic*>* */ {
         unsafe { msg_send![cbservice, characteristics] }
     }
 
     // CBCharacteristic : CBAttribute
 
-    pub fn characteristic_isnotifying(cbcharacteristic: *mut Object) -> BOOL {
+    pub fn characteristic_isnotifying(cbcharacteristic: id) -> BOOL {
         unsafe { msg_send![cbcharacteristic, isNotifying] }
     }
 
-    pub fn characteristic_value(cbcharacteristic: *mut Object) -> *mut Object /* NSData* */ {
+    pub fn characteristic_value(cbcharacteristic: id) -> id /* NSData* */ {
         unsafe { msg_send![cbcharacteristic, value] }
     }
 
-    pub fn characteristic_properties(cbcharacteristic: *mut Object) -> c_uint {
+    pub fn characteristic_properties(cbcharacteristic: id) -> c_uint {
         unsafe { msg_send![cbcharacteristic, properties] }
     }
 
-    pub fn characteristic_service(cbcharacteristic: *mut Object) -> *mut Object /* CBService* */ {
+    pub fn characteristic_service(cbcharacteristic: id) -> id /* CBService* */ {
         unsafe { msg_send![cbcharacteristic, service] }
     }
 
@@ -351,11 +341,11 @@ pub mod cb {
 
     // CBUUID
 
-    pub fn uuid_uuidstring(cbuuid: *mut Object) -> *mut Object /* NSString* */ {
+    pub fn uuid_uuidstring(cbuuid: id) -> id /* NSString* */ {
         unsafe { msg_send![cbuuid, UUIDString] }
     }
 
-    pub fn uuid_uuidwithstring(s: *mut Object /* NSString */) -> *mut Object /* CBUUID */ {
+    pub fn uuid_uuidwithstring(s: id /* NSString */) -> id /* CBUUID */ {
         unsafe { msg_send![class!(CBUUID), UUIDWithString: s] }
     }
 

--- a/src/corebluetooth/framework.rs
+++ b/src/corebluetooth/framework.rs
@@ -85,8 +85,10 @@ pub mod ns {
 
     // NSData
 
-    pub fn data(bytes: *const u8, length: c_uint) -> id /* NSData* */ {
-        unsafe { msg_send![class!(NSData), dataWithBytes:bytes length:length] }
+    pub fn data(bytes: &[u8]) -> id /* NSData* */ {
+        unsafe {
+            msg_send![class!(NSData), dataWithBytes:bytes.as_ptr() length:bytes.len() as NSUInteger]
+        }
     }
 
     pub fn data_length(nsdata: id) -> c_uint {

--- a/src/corebluetooth/framework.rs
+++ b/src/corebluetooth/framework.rs
@@ -16,13 +16,13 @@
 // This file may not be copied, modified, or distributed except
 // according to those terms.
 
-use cocoa::{base::id, foundation::NSUInteger};
+use cocoa::{
+    base::{id, nil},
+    foundation::NSUInteger,
+};
 use objc::runtime::BOOL;
 use objc::{class, msg_send, sel, sel_impl};
 use std::os::raw::{c_char, c_int, c_uint};
-
-#[allow(non_upper_case_globals)]
-pub const nil: id = 0 as id;
 
 pub mod ns {
     use super::*;

--- a/src/corebluetooth/framework.rs
+++ b/src/corebluetooth/framework.rs
@@ -33,16 +33,6 @@ pub mod ns {
         unsafe { msg_send![class!(NSNumber), numberWithBool: value] }
     }
 
-    // NSString
-
-    pub fn string(cstring: *const c_char) -> id /* NSString* */ {
-        unsafe { msg_send![class!(NSString), stringWithUTF8String: cstring] }
-    }
-
-    pub fn string_utf8string(nsstring: id) -> *const c_char {
-        unsafe { msg_send![nsstring, UTF8String] }
-    }
-
     // NSArray
 
     pub fn array_count(nsarray: id) -> c_uint {

--- a/src/corebluetooth/framework.rs
+++ b/src/corebluetooth/framework.rs
@@ -327,7 +327,7 @@ pub mod cb {
         unsafe { msg_send![cbuuid, UUIDString] }
     }
 
-    pub fn uuid_uuidwithstring(s: id /* NSString */) -> id /* CBUUID */ {
+    pub fn uuid_uuidwithstring(s: impl NSString) -> id /* CBUUID */ {
         unsafe { msg_send![class!(CBUUID), UUIDWithString: s] }
     }
 

--- a/src/corebluetooth/framework.rs
+++ b/src/corebluetooth/framework.rs
@@ -27,29 +27,10 @@ pub const nil: *mut Object = 0 as *mut Object;
 pub mod ns {
     use super::*;
 
-    // NSObject
-
-    pub fn object_copy(nsobject: *mut Object) -> *mut Object {
-        unsafe { msg_send![nsobject, copy] }
-    }
-
     // NSNumber
 
     pub fn number_withbool(value: BOOL) -> *mut Object {
         unsafe { msg_send![Class::get("NSNumber").unwrap(), numberWithBool: value] }
-    }
-
-    pub fn number_withunsignedlonglong(value: u64) -> *mut Object {
-        unsafe {
-            msg_send![
-                Class::get("NSNumber").unwrap(),
-                numberWithUnsignedLongLong: value
-            ]
-        }
-    }
-
-    pub fn number_unsignedlonglongvalue(nsnumber: *mut Object) -> u64 {
-        unsafe { msg_send![nsnumber, unsignedLongLongValue] }
     }
 
     // NSString
@@ -103,10 +84,6 @@ pub mod ns {
         unsafe { msg_send![Class::get("NSMutableDictionary").unwrap(), dictionaryWithCapacity:0] }
     }
 
-    pub fn mutabledictionary_removeobjectforkey(nsmutdict: *mut Object, key: *mut Object) {
-        unsafe { msg_send![nsmutdict, removeObjectForKey: key] }
-    }
-
     pub fn mutabledictionary_setobject_forkey(
         nsmutdict: *mut Object,
         object: *mut Object,
@@ -135,67 +112,6 @@ pub mod ns {
         unsafe {
             let uuidstring: *mut Object = msg_send![nsuuid, UUIDString];
             uuidstring
-        }
-    }
-}
-
-pub mod io {
-    use super::*;
-
-    #[link(name = "IOBluetooth", kind = "framework")]
-    extern "C" {
-        pub fn IOBluetoothPreferenceGetControllerPowerState() -> c_int;
-        pub fn IOBluetoothPreferenceSetControllerPowerState(state: c_int);
-
-        pub fn IOBluetoothPreferenceGetDiscoverableState() -> c_int;
-        pub fn IOBluetoothPreferenceSetDiscoverableState(state: c_int);
-    }
-
-    // IOBluetoothHostController
-
-    pub fn bluetoothhostcontroller_defaultcontroller() -> *mut Object /* IOBluetoothHostController* */
-    {
-        unsafe {
-            msg_send![
-                Class::get("IOBluetoothHostController").unwrap(),
-                defaultController
-            ]
-        }
-    }
-
-    pub fn bluetoothhostcontroller_nameasstring(iobthc: *mut Object) -> *mut Object /* NSString* */
-    {
-        unsafe { msg_send![iobthc, nameAsString] }
-    }
-
-    pub fn bluetoothhostcontroller_addressasstring(iobthc: *mut Object) -> *mut Object /* NSString* */
-    {
-        unsafe { msg_send![iobthc, addressAsString] }
-    }
-
-    pub fn bluetoothhostcontroller_classofdevice(iobthc: *mut Object) -> u32 {
-        unsafe { msg_send![iobthc, classOfDevice] }
-    }
-
-    // IOBluetoothPreference...
-
-    pub fn bluetoothpreferencegetcontrollerpowerstate() -> c_int {
-        unsafe { IOBluetoothPreferenceGetControllerPowerState() }
-    }
-
-    pub fn bluetoothpreferencesetcontrollerpowerstate(state: c_int) {
-        unsafe {
-            IOBluetoothPreferenceSetControllerPowerState(state);
-        }
-    }
-
-    pub fn bluetoothpreferencegetdiscoverablestate() -> c_int {
-        unsafe { IOBluetoothPreferenceGetDiscoverableState() }
-    }
-
-    pub fn bluetoothpreferencesetdiscoverablestate(state: c_int) {
-        unsafe {
-            IOBluetoothPreferenceSetDiscoverableState(state);
         }
     }
 }

--- a/src/corebluetooth/framework.rs
+++ b/src/corebluetooth/framework.rs
@@ -18,7 +18,7 @@
 
 use cocoa::{
     base::{id, nil},
-    foundation::NSUInteger,
+    foundation::{NSArray, NSData, NSDictionary, NSString, NSUInteger},
 };
 use objc::runtime::BOOL;
 use objc::{class, msg_send, sel, sel_impl};
@@ -35,32 +35,22 @@ pub mod ns {
 
     // NSArray
 
-    pub fn array_count(nsarray: id) -> c_uint {
-        unsafe { msg_send![nsarray, count] }
+    pub fn array_count(nsarray: impl NSArray) -> NSUInteger {
+        unsafe { nsarray.count() }
     }
 
-    pub fn array_objectatindex(nsarray: id, index: c_uint) -> id {
-        unsafe { msg_send![nsarray, objectAtIndex: index] }
-    }
-
-    pub fn arraywithobjects_count(objects: *const id, count: NSUInteger) -> id {
-        unsafe {
-            msg_send![
-                class!(NSArray),
-                arrayWithObjects: objects
-                count: count
-            ]
-        }
+    pub fn array_objectatindex(nsarray: impl NSArray, index: NSUInteger) -> id {
+        unsafe { nsarray.objectAtIndex(index) }
     }
 
     // NSDictionary
 
-    pub fn dictionary_allkeys(nsdict: id) -> id /* NSArray* */ {
-        unsafe { msg_send![nsdict, allKeys] }
+    pub fn dictionary_allkeys(nsdict: impl NSDictionary) -> id /* NSArray* */ {
+        unsafe { nsdict.allKeys() }
     }
 
-    pub fn dictionary_objectforkey(nsdict: id, key: id) -> id {
-        unsafe { msg_send![nsdict, objectForKey: key] }
+    pub fn dictionary_objectforkey(nsdict: impl NSDictionary, key: id) -> id {
+        unsafe { nsdict.objectForKey_(key) }
     }
 
     // NSMutableDictionary : NSDictionary
@@ -81,8 +71,8 @@ pub mod ns {
         }
     }
 
-    pub fn data_length(nsdata: id) -> c_uint {
-        unsafe { msg_send![nsdata, length] }
+    pub fn data_length(nsdata: impl NSData) -> NSUInteger {
+        unsafe { nsdata.length() }
     }
 
     pub fn data_bytes(nsdata: id) -> *const u8 {

--- a/src/corebluetooth/framework.rs
+++ b/src/corebluetooth/framework.rs
@@ -17,8 +17,8 @@
 // according to those terms.
 
 use cocoa::foundation::NSUInteger;
-use objc::runtime::{Class, Object, BOOL};
-use objc::{msg_send, sel, sel_impl};
+use objc::runtime::{Object, BOOL};
+use objc::{class, msg_send, sel, sel_impl};
 use std::os::raw::{c_char, c_int, c_uint};
 
 #[allow(non_upper_case_globals)]
@@ -30,18 +30,13 @@ pub mod ns {
     // NSNumber
 
     pub fn number_withbool(value: BOOL) -> *mut Object {
-        unsafe { msg_send![Class::get("NSNumber").unwrap(), numberWithBool: value] }
+        unsafe { msg_send![class!(NSNumber), numberWithBool: value] }
     }
 
     // NSString
 
     pub fn string(cstring: *const c_char) -> *mut Object /* NSString* */ {
-        unsafe {
-            msg_send![
-                Class::get("NSString").unwrap(),
-                stringWithUTF8String: cstring
-            ]
-        }
+        unsafe { msg_send![class!(NSString), stringWithUTF8String: cstring] }
     }
 
     pub fn string_utf8string(nsstring: *mut Object) -> *const c_char {
@@ -61,7 +56,7 @@ pub mod ns {
     pub fn arraywithobjects_count(objects: *const *mut Object, count: NSUInteger) -> *mut Object {
         unsafe {
             msg_send![
-                Class::get("NSArray").unwrap(),
+                class!(NSArray),
                 arrayWithObjects: objects
                 count: count
             ]
@@ -81,7 +76,7 @@ pub mod ns {
     // NSMutableDictionary : NSDictionary
 
     pub fn mutabledictionary() -> *mut Object {
-        unsafe { msg_send![Class::get("NSMutableDictionary").unwrap(), dictionaryWithCapacity:0] }
+        unsafe { msg_send![class!(NSMutableDictionary), dictionaryWithCapacity:0] }
     }
 
     pub fn mutabledictionary_setobject_forkey(
@@ -95,7 +90,7 @@ pub mod ns {
     // NSData
 
     pub fn data(bytes: *const u8, length: c_uint) -> *mut Object /* NSData* */ {
-        unsafe { msg_send![Class::get("NSData").unwrap(), dataWithBytes:bytes length:length] }
+        unsafe { msg_send![class!(NSData), dataWithBytes:bytes length:length] }
     }
 
     pub fn data_length(nsdata: *mut Object) -> c_uint {
@@ -157,8 +152,7 @@ pub mod cb {
     {
         let label = CString::new("CBqueue").unwrap();
         unsafe {
-            let cbcentralmanager: *mut Object =
-                msg_send![Class::get("CBCentralManager").unwrap(), alloc];
+            let cbcentralmanager: *mut Object = msg_send![class!(CBCentralManager), alloc];
             let queue = dispatch_queue_create(label.as_ptr(), DISPATCH_QUEUE_SERIAL);
 
             msg_send![cbcentralmanager, initWithDelegate:delegate queue:queue]
@@ -195,7 +189,7 @@ pub mod cb {
 
     // CBManager
     pub fn manager_authorization() -> CBManagerAuthorization {
-        unsafe { msg_send![Class::get("CBManager").unwrap(), authorization] }
+        unsafe { msg_send![class!(CBManager), authorization] }
     }
 
     #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -362,7 +356,7 @@ pub mod cb {
     }
 
     pub fn uuid_uuidwithstring(s: *mut Object /* NSString */) -> *mut Object /* CBUUID */ {
-        unsafe { msg_send![Class::get("CBUUID").unwrap(), UUIDWithString: s] }
+        unsafe { msg_send![class!(CBUUID), UUIDWithString: s] }
     }
 
     // CBCentralManagerScanOption...Key

--- a/src/corebluetooth/internal.rs
+++ b/src/corebluetooth/internal.rs
@@ -12,7 +12,7 @@ use super::{
     central_delegate::{CentralDelegate, CentralDelegateEvent},
     framework::{
         cb::{self, CBManagerAuthorization, CBPeripheralState},
-        nil, ns,
+        ns,
     },
     future::{BtlePlugFuture, BtlePlugFutureStateShared},
     utils::{
@@ -23,7 +23,10 @@ use super::{
 };
 use crate::api::{CharPropFlags, Characteristic, ScanFilter, Service, WriteType};
 use crate::Error;
-use cocoa::{base::id, foundation::NSUInteger};
+use cocoa::{
+    base::{id, nil},
+    foundation::NSUInteger,
+};
 use futures::channel::mpsc::{self, Receiver, Sender};
 use futures::select;
 use futures::sink::SinkExt;

--- a/src/corebluetooth/internal.rs
+++ b/src/corebluetooth/internal.rs
@@ -37,7 +37,6 @@ use std::{
     collections::{BTreeSet, HashMap, VecDeque},
     fmt::{self, Debug, Formatter},
     ops::Deref,
-    os::raw::c_uint,
     thread,
 };
 use tokio::runtime;
@@ -619,7 +618,7 @@ impl CoreBluetoothInternal {
                     trace!("Writing value! With kind {:?}", kind);
                     cb::peripheral_writevalue_forcharacteristic(
                         *peripheral.peripheral,
-                        ns::data(data.as_ptr(), data.len() as c_uint),
+                        ns::data(&data),
                         *characteristic.characteristic,
                         match kind {
                             WriteType::WithResponse => 0,

--- a/src/corebluetooth/internal.rs
+++ b/src/corebluetooth/internal.rs
@@ -25,7 +25,7 @@ use crate::api::{CharPropFlags, Characteristic, ScanFilter, Service, WriteType};
 use crate::Error;
 use cocoa::{
     base::{id, nil},
-    foundation::NSUInteger,
+    foundation::NSArray,
 };
 use futures::channel::mpsc::{self, Receiver, Sender};
 use futures::select;
@@ -833,7 +833,7 @@ fn scan_filter_to_service_uuids(filter: ScanFilter) -> id {
             .into_iter()
             .map(uuid_to_cbuuid)
             .collect::<Vec<_>>();
-        ns::arraywithobjects_count(service_uuids.as_ptr(), service_uuids.len() as NSUInteger)
+        unsafe { NSArray::arrayWithObjects(nil, &service_uuids) }
     }
 }
 

--- a/src/corebluetooth/internal.rs
+++ b/src/corebluetooth/internal.rs
@@ -23,16 +23,13 @@ use super::{
 };
 use crate::api::{CharPropFlags, Characteristic, ScanFilter, Service, WriteType};
 use crate::Error;
-use cocoa::foundation::NSUInteger;
+use cocoa::{base::id, foundation::NSUInteger};
 use futures::channel::mpsc::{self, Receiver, Sender};
 use futures::select;
 use futures::sink::SinkExt;
 use futures::stream::{Fuse, StreamExt};
 use log::{error, trace, warn};
-use objc::{
-    rc::StrongPtr,
-    runtime::{Object, YES},
-};
+use objc::{rc::StrongPtr, runtime::YES};
 use std::{
     collections::{BTreeSet, HashMap, VecDeque},
     fmt::{self, Debug, Formatter},
@@ -82,7 +79,7 @@ impl CBCharacteristic {
         }
     }
 
-    fn form_flags(characteristic: *mut Object) -> CharPropFlags {
+    fn form_flags(characteristic: id) -> CharPropFlags {
         let flags = cb::characteristic_properties(characteristic);
         let mut v = CharPropFlags::default();
         if (flags & cb::CHARACTERISTICPROPERTY_BROADCAST) != 0 {
@@ -825,7 +822,7 @@ impl CoreBluetoothInternal {
 
 /// Convert a `ScanFilter` to the appropriate `NSArray<CBUUID *> *` to use for discovery. If the
 /// filter has an empty list of services then this will return `nil`, to discover all devices.
-fn scan_filter_to_service_uuids(filter: ScanFilter) -> *mut Object {
+fn scan_filter_to_service_uuids(filter: ScanFilter) -> id {
     if filter.services.is_empty() {
         nil
     } else {

--- a/src/corebluetooth/utils/core_bluetooth.rs
+++ b/src/corebluetooth/utils/core_bluetooth.rs
@@ -76,8 +76,7 @@ pub fn characteristic_debug(characteristic: *mut Object) -> String {
 #[cfg(test)]
 mod tests {
     use super::super::nsstring::str_to_nsstring;
-    use objc::runtime::Class;
-    use objc::{msg_send, sel, sel_impl};
+    use objc::{class, msg_send, sel, sel_impl};
 
     use super::*;
 
@@ -86,7 +85,7 @@ mod tests {
         let uuid_string = "1234";
         let uuid_nsstring = str_to_nsstring(uuid_string);
         let cbuuid: *mut Object =
-            unsafe { msg_send![Class::get("CBUUID").unwrap(), UUIDWithString: uuid_nsstring] };
+            unsafe { msg_send![class!(CBUUID), UUIDWithString: uuid_nsstring] };
         let uuid = cbuuid_to_uuid(cbuuid);
         assert_eq!(
             uuid,
@@ -98,7 +97,7 @@ mod tests {
     fn parse_uuid_long() {
         let uuid_nsstring = str_to_nsstring("12345678-0000-1111-2222-333344445555");
         let cbuuid: *mut Object =
-            unsafe { msg_send![Class::get("CBUUID").unwrap(), UUIDWithString: uuid_nsstring] };
+            unsafe { msg_send![class!(CBUUID), UUIDWithString: uuid_nsstring] };
         let uuid = cbuuid_to_uuid(cbuuid);
         assert_eq!(
             uuid,

--- a/src/corebluetooth/utils/core_bluetooth.rs
+++ b/src/corebluetooth/utils/core_bluetooth.rs
@@ -16,10 +16,10 @@
 // This file may not be copied, modified, or distributed except
 // according to those terms.
 
-use cocoa::base::id;
+use cocoa::base::{id, nil};
 use uuid::Uuid;
 
-use super::super::framework::{cb, nil, ns};
+use super::super::framework::{cb, ns};
 use super::nsstring::{nsstring_to_string, str_to_nsstring};
 
 /// Convert a CBUUID object to the standard Uuid type.

--- a/src/corebluetooth/utils/core_bluetooth.rs
+++ b/src/corebluetooth/utils/core_bluetooth.rs
@@ -16,14 +16,14 @@
 // This file may not be copied, modified, or distributed except
 // according to those terms.
 
-use objc::runtime::Object;
+use cocoa::base::id;
 use uuid::Uuid;
 
 use super::super::framework::{cb, nil, ns};
 use super::nsstring::{nsstring_to_string, str_to_nsstring};
 
 /// Convert a CBUUID object to the standard Uuid type.
-pub fn cbuuid_to_uuid(cbuuid: *mut Object) -> Uuid {
+pub fn cbuuid_to_uuid(cbuuid: id) -> Uuid {
     // NOTE: CoreBluetooth tends to return uppercase UUID strings, and only 4
     // character long if the UUID is short (16 bits). It can also return 8
     // character strings if the rest of the UUID matches the generic UUID.
@@ -40,11 +40,11 @@ pub fn cbuuid_to_uuid(cbuuid: *mut Object) -> Uuid {
 }
 
 /// Convert a `Uuid` to a `CBUUID`.
-pub fn uuid_to_cbuuid(uuid: Uuid) -> *mut Object {
+pub fn uuid_to_cbuuid(uuid: Uuid) -> id {
     cb::uuid_uuidwithstring(str_to_nsstring(&uuid.to_string()))
 }
 
-pub fn peripheral_debug(peripheral: *mut Object) -> String {
+pub fn peripheral_debug(peripheral: id) -> String {
     if peripheral == nil {
         return String::from("nil");
     }
@@ -57,7 +57,7 @@ pub fn peripheral_debug(peripheral: *mut Object) -> String {
     }
 }
 
-pub fn service_debug(service: *mut Object) -> String {
+pub fn service_debug(service: id) -> String {
     if service == nil {
         return String::from("nil");
     }
@@ -65,7 +65,7 @@ pub fn service_debug(service: *mut Object) -> String {
     format!("CBService({})", nsstring_to_string(uuid).unwrap())
 }
 
-pub fn characteristic_debug(characteristic: *mut Object) -> String {
+pub fn characteristic_debug(characteristic: id) -> String {
     if characteristic == nil {
         return String::from("nil");
     }
@@ -84,8 +84,7 @@ mod tests {
     fn parse_uuid_short() {
         let uuid_string = "1234";
         let uuid_nsstring = str_to_nsstring(uuid_string);
-        let cbuuid: *mut Object =
-            unsafe { msg_send![class!(CBUUID), UUIDWithString: uuid_nsstring] };
+        let cbuuid: id = unsafe { msg_send![class!(CBUUID), UUIDWithString: uuid_nsstring] };
         let uuid = cbuuid_to_uuid(cbuuid);
         assert_eq!(
             uuid,
@@ -96,8 +95,7 @@ mod tests {
     #[test]
     fn parse_uuid_long() {
         let uuid_nsstring = str_to_nsstring("12345678-0000-1111-2222-333344445555");
-        let cbuuid: *mut Object =
-            unsafe { msg_send![class!(CBUUID), UUIDWithString: uuid_nsstring] };
+        let cbuuid: id = unsafe { msg_send![class!(CBUUID), UUIDWithString: uuid_nsstring] };
         let uuid = cbuuid_to_uuid(cbuuid);
         assert_eq!(
             uuid,

--- a/src/corebluetooth/utils/core_bluetooth.rs
+++ b/src/corebluetooth/utils/core_bluetooth.rs
@@ -75,8 +75,8 @@ pub fn characteristic_debug(characteristic: id) -> String {
 
 #[cfg(test)]
 mod tests {
+    use super::super::super::framework::cb::uuid_uuidwithstring;
     use super::super::nsstring::str_to_nsstring;
-    use objc::{class, msg_send, sel, sel_impl};
 
     use super::*;
 
@@ -84,7 +84,7 @@ mod tests {
     fn parse_uuid_short() {
         let uuid_string = "1234";
         let uuid_nsstring = str_to_nsstring(uuid_string);
-        let cbuuid: id = unsafe { msg_send![class!(CBUUID), UUIDWithString: uuid_nsstring] };
+        let cbuuid = uuid_uuidwithstring(uuid_nsstring);
         let uuid = cbuuid_to_uuid(cbuuid);
         assert_eq!(
             uuid,
@@ -95,7 +95,7 @@ mod tests {
     #[test]
     fn parse_uuid_long() {
         let uuid_nsstring = str_to_nsstring("12345678-0000-1111-2222-333344445555");
-        let cbuuid: id = unsafe { msg_send![class!(CBUUID), UUIDWithString: uuid_nsstring] };
+        let cbuuid = uuid_uuidwithstring(uuid_nsstring);
         let uuid = cbuuid_to_uuid(cbuuid);
         assert_eq!(
             uuid,

--- a/src/corebluetooth/utils/mod.rs
+++ b/src/corebluetooth/utils/mod.rs
@@ -16,7 +16,7 @@
 // This file may not be copied, modified, or distributed except
 // according to those terms.
 
-use objc::runtime::Object;
+use cocoa::base::id;
 use std::slice;
 use uuid::Uuid;
 
@@ -26,7 +26,7 @@ use super::framework::ns;
 pub mod core_bluetooth;
 pub mod nsstring;
 
-pub fn nsdata_to_vec(data: *mut Object) -> Vec<u8> {
+pub fn nsdata_to_vec(data: id) -> Vec<u8> {
     let length = ns::data_length(data);
     if length == 0 {
         return vec![];
@@ -35,7 +35,7 @@ pub fn nsdata_to_vec(data: *mut Object) -> Vec<u8> {
     unsafe { slice::from_raw_parts(bytes, length as usize).to_vec() }
 }
 
-pub fn nsuuid_to_uuid(uuid: *mut Object) -> Uuid {
+pub fn nsuuid_to_uuid(uuid: id) -> Uuid {
     let uuid_nsstring = ns::uuid_uuidstring(uuid);
     nsstring_to_string(uuid_nsstring).unwrap().parse().unwrap()
 }

--- a/src/corebluetooth/utils/nsstring.rs
+++ b/src/corebluetooth/utils/nsstring.rs
@@ -16,13 +16,13 @@
 // This file may not be copied, modified, or distributed except
 // according to those terms.
 
-use objc::runtime::Object;
+use cocoa::base::id;
 use std::ffi::{CStr, CString};
 
 use super::super::framework::{nil, ns};
 
 /// Convert the given `NSString` to a Rust `String`, or `None` if it is `nil`.
-pub fn nsstring_to_string(nsstring: *mut Object) -> Option<String> {
+pub fn nsstring_to_string(nsstring: id) -> Option<String> {
     if nsstring == nil {
         return None;
     }
@@ -36,7 +36,7 @@ pub fn nsstring_to_string(nsstring: *mut Object) -> Option<String> {
 }
 
 #[allow(dead_code)]
-pub fn str_to_nsstring(string: &str) -> *mut Object {
+pub fn str_to_nsstring(string: &str) -> id {
     let cstring = CString::new(string).unwrap();
     ns::string(cstring.as_ptr())
 }

--- a/src/corebluetooth/utils/nsstring.rs
+++ b/src/corebluetooth/utils/nsstring.rs
@@ -16,10 +16,11 @@
 // This file may not be copied, modified, or distributed except
 // according to those terms.
 
-use cocoa::base::{id, nil};
-use std::ffi::{CStr, CString};
-
-use super::super::framework::ns;
+use cocoa::{
+    base::{id, nil},
+    foundation::NSString,
+};
+use std::ffi::CStr;
 
 /// Convert the given `NSString` to a Rust `String`, or `None` if it is `nil`.
 pub fn nsstring_to_string(nsstring: id) -> Option<String> {
@@ -28,15 +29,11 @@ pub fn nsstring_to_string(nsstring: id) -> Option<String> {
     }
     unsafe {
         Some(String::from(
-            CStr::from_ptr(ns::string_utf8string(nsstring))
-                .to_str()
-                .unwrap(),
+            CStr::from_ptr(nsstring.UTF8String()).to_str().unwrap(),
         ))
     }
 }
 
-#[allow(dead_code)]
 pub fn str_to_nsstring(string: &str) -> id {
-    let cstring = CString::new(string).unwrap();
-    ns::string(cstring.as_ptr())
+    unsafe { NSString::alloc(nil).init_str(string) }
 }

--- a/src/corebluetooth/utils/nsstring.rs
+++ b/src/corebluetooth/utils/nsstring.rs
@@ -16,10 +16,10 @@
 // This file may not be copied, modified, or distributed except
 // according to those terms.
 
-use cocoa::base::id;
+use cocoa::base::{id, nil};
 use std::ffi::{CStr, CString};
 
-use super::super::framework::{nil, ns};
+use super::super::framework::ns;
 
 /// Convert the given `NSString` to a Rust `String`, or `None` if it is `nil`.
 pub fn nsstring_to_string(nsstring: id) -> Option<String> {


### PR DESCRIPTION
I've removed a few unused functions, used some of the wrappers and types from the `cocoa` crate (seeing as we are depending on it anyway) and some of the helpers we already have. This simplifies some of the code a bit.