### PR TITLE
add a trait PeripheralIdent, and a hashing mechanism for Peripheral.

### DIFF
--- a/examples/hashing.rs
+++ b/examples/hashing.rs
@@ -1,0 +1,62 @@
+// See the "macOS permissions note" in README.md before running this on macOS
+// Big Sur or later.
+
+use btleplug::api::{Central, CentralEvent, Manager as _, PeripheralIdent, ScanFilter};
+use btleplug::platform::{Adapter, Manager, Peripheral, PeripheralId, PeripheralIdKeyed};
+use futures::stream::StreamExt;
+use std::collections::HashSet;
+use std::error::Error;
+
+async fn get_central(manager: &Manager) -> Adapter {
+    let adapters = manager.adapters().await.unwrap();
+    adapters.into_iter().nth(0).unwrap()
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    pretty_env_logger::init();
+    let manager = Manager::new().await?;
+    let central = get_central(&manager).await;
+    let mut events = central.events().await?;
+    let mut ids = HashSet::<PeripheralId>::new();
+    let mut keys = HashSet::<PeripheralIdKeyed>::new();
+    central.start_scan(ScanFilter::default()).await?;
+
+    while let Some(event) = events.next().await {
+        match &event {
+            CentralEvent::DeviceDiscovered(id) => {
+                let periph = central.peripheral(&id).await?;
+                assert!(event.id() == periph.id() && id.id() == *id);
+                ids.insert(event.id());
+                // Peripheral doesn't implement Hash, but PeripheralIdentKey does,
+                // It hashes a periheral based upon the hash of its PeripheralId.
+                //
+                // If the platform returns the same PeripheralId for peripherals on
+                // different adapters (untested), then PeripheralIdKeyed would have the same hash
+                // for both.
+
+                let periph_clone = periph.clone();
+                // periph moved into keys.
+                keys.insert(periph.into());
+                keys.contains(event.get_id());
+                keys.contains(id.get_id());
+                assert!(
+                    keys.contains(event.get_id())
+                        && keys.contains(periph_clone.get_id())
+                        && keys.contains(id)
+                );
+
+                // move a PeripheralIdKeyed out, and get our Peripheral from it.
+                let periph: Peripheral = keys.take(id).expect("Peripheral not in set").peripheral();
+                assert!(periph.id() == periph_clone.id())
+            }
+            _ => {
+                let id = event.id();
+                if !ids.contains(&id) {
+                    ids.insert(id);
+                }
+            }
+        }
+    }
+    Ok(())
+}

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -15,8 +15,67 @@ pub use crate::winrtble::{
 };
 
 use crate::api::{self, Central};
+use api::PeripheralIdent;
 use static_assertions::assert_impl_all;
+use std::borrow::Borrow;
 use std::fmt::Debug;
+use std::hash::{Hash, Hasher};
+
+impl PeripheralIdent for PeripheralId {
+    fn id(&self) -> Self {
+        self.clone()
+    }
+    fn get_id(&self) -> &Self {
+        self
+    }
+}
+
+// This implements hash based on the PeripheralId of a Peripheral.
+// Peripheral doesn't currently implement Hash, and you could consider that the same Peripheral
+// connected to via different Adapters should hash differently
+pub struct PeripheralIdKeyed {
+    peripheral: Peripheral,
+}
+
+impl Borrow<PeripheralId> for PeripheralIdKeyed {
+    fn borrow(&self) -> &PeripheralId {
+        self.get_id()
+    }
+}
+
+impl From<Peripheral> for PeripheralIdKeyed {
+    fn from(peripheral: Peripheral) -> PeripheralIdKeyed {
+        PeripheralIdKeyed { peripheral }
+    }
+}
+
+impl PeripheralIdKeyed {
+    pub fn peripheral(self) -> Peripheral {
+        self.peripheral
+    }
+}
+
+impl PeripheralIdent for PeripheralIdKeyed {
+    fn id(&self) -> PeripheralId {
+        self.peripheral.id()
+    }
+    fn get_id(&self) -> &PeripheralId {
+        self.peripheral.get_id()
+    }
+}
+
+impl Eq for PeripheralIdKeyed {}
+impl PartialEq for PeripheralIdKeyed {
+    fn eq(&self, other: &PeripheralIdKeyed) -> bool {
+        *self.peripheral.get_id() == *other.peripheral.get_id()
+    }
+}
+
+impl Hash for PeripheralIdKeyed {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.get_id().hash(state)
+    }
+}
 
 // Ensure that the exported types implement all the expected traits.
 assert_impl_all!(Adapter: Central, Clone, Debug, Send, Sized, Sync);


### PR DESCRIPTION
This adds a newtype around Peripheral, and moves the id() function of
the Peripheral trait to a new trait PeripheralIdent.

PeripheralIdent is implemented for CentralEvent, Peripheral, PeripheralId,
and PeripheralIdent.

A newtype PeripheralIdKeyed which has a Peripheral is added,
This implements Hash, and Borrow for PeripheralId.

So you can test an event/id/peripheral against a PeripheralIdKeyed in
a HashMap.

see the examples/hashing.rs in the commit.