### PR TITLE
Derive Ord for BDAddr and PeripheralId.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Unreleased
 
+## Features
+
+- `BDAddr` and `PeripheralId` are now guaranteed to implement `Hash`, `Ord` and `PartialOrd` on all
+  platforms.
+
 ## Bugfixes
 
 - Linux implementation will now synthesise `DeviceConnected` events at the start of the event stream

--- a/src/api/bdaddr.rs
+++ b/src/api/bdaddr.rs
@@ -5,7 +5,7 @@ use std::fmt::{self, Debug, Display, Formatter, LowerHex, UpperHex};
 use std::str::FromStr;
 
 /// Stores the 6 byte address used to identify Bluetooth devices.
-#[derive(Copy, Clone, Hash, Eq, PartialEq, Default)]
+#[derive(Copy, Clone, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct BDAddr {
     address: [u8; 6],
 }

--- a/src/bluez/peripheral.rs
+++ b/src/bluez/peripheral.rs
@@ -31,7 +31,7 @@ struct ServiceInternal {
     derive(Serialize, Deserialize),
     serde(crate = "serde_cr")
 )]
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct PeripheralId(BDAddr);
 
 /// Implementation of [api::Peripheral](crate::api::Peripheral).

--- a/src/corebluetooth/peripheral.rs
+++ b/src/corebluetooth/peripheral.rs
@@ -44,7 +44,7 @@ use uuid::Uuid;
     derive(Serialize, Deserialize),
     serde(crate = "serde_cr")
 )]
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct PeripheralId(Uuid);
 
 /// Implementation of [api::Peripheral](crate::api::Peripheral).

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -16,10 +16,21 @@ pub use crate::winrtble::{
 
 use crate::api::{self, Central};
 use static_assertions::assert_impl_all;
-use std::fmt::Debug;
+use std::{fmt::Debug, hash::Hash};
 
 // Ensure that the exported types implement all the expected traits.
 assert_impl_all!(Adapter: Central, Clone, Debug, Send, Sized, Sync);
 assert_impl_all!(Manager: api::Manager, Clone, Debug, Send, Sized, Sync);
 assert_impl_all!(Peripheral: api::Peripheral, Clone, Debug, Send, Sized, Sync);
-assert_impl_all!(PeripheralId: Clone, Debug, Send, Sized, Sync, Eq, PartialEq);
+assert_impl_all!(
+    PeripheralId: Clone,
+    Debug,
+    Hash,
+    Eq,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    Send,
+    Sized,
+    Sync
+);

--- a/src/winrtble/peripheral.rs
+++ b/src/winrtble/peripheral.rs
@@ -51,7 +51,7 @@ use windows::Devices::Bluetooth::{Advertisement::*, BluetoothAddressType};
     derive(Serialize, Deserialize),
     serde(crate = "serde_cr")
 )]
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct PeripheralId(BDAddr);
 
 /// Implementation of [api::Peripheral](crate::api::Peripheral).


### PR DESCRIPTION
Also ensure that `PeripheralId` implements `Hash` on all platforms.