### PR TITLE
Make Central methods on Bluez Adapter only affect that adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 - Linux implementation will now synthesise `DeviceConnected` events at the start of the event stream
   for all peripherals which were already connected at the point that the event stream was requested.
+- `Central` methods on Linux will now correctly only affect the correct Bluetooth adapter, rather
+  than all adapters on the system.
 
 # 0.9.0 (2021-10-20)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ dbus = "0.9.5"
 displaydoc = "0.2.3"
 parking_lot = "0.11.2"
 tokio = { version = "1.14.0", features = ["rt"] }
-bluez-async = "0.5.0"
+bluez-async = "0.5.4"
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 cocoa = "0.24.0"

--- a/src/bluez/adapter.rs
+++ b/src/bluez/adapter.rs
@@ -30,7 +30,7 @@ impl Central for Adapter {
         // There's a race between getting this event stream and getting the current set of devices.
         // Get the stream first, on the basis that it's better to have a duplicate DeviceDiscovered
         // event than to miss one. It's unlikely to happen in any case.
-        let events = self.session.event_stream().await?;
+        let events = self.session.adapter_event_stream(&self.adapter).await?;
 
         // Synthesise `DeviceDiscovered' and `DeviceConnected` events for existing peripherals.
         let devices = self.session.get_devices().await?;

--- a/src/bluez/adapter.rs
+++ b/src/bluez/adapter.rs
@@ -108,59 +108,47 @@ async fn central_event(event: BluetoothEvent, session: BluetoothSession) -> Opti
     match event {
         BluetoothEvent::Device {
             id,
-            event: DeviceEvent::Discovered,
-        } => {
-            let device = session.get_device_info(&id).await.ok()?;
-            Some(CentralEvent::DeviceDiscovered(device.mac_address.into()))
-        }
-        BluetoothEvent::Device {
-            id,
-            event: DeviceEvent::Connected { connected },
-        } => {
-            let device = session.get_device_info(&id).await.ok()?;
-            if connected {
-                Some(CentralEvent::DeviceConnected(device.mac_address.into()))
-            } else {
-                Some(CentralEvent::DeviceDisconnected(device.mac_address.into()))
+            event: device_event,
+        } => match device_event {
+            DeviceEvent::Discovered => {
+                let device = session.get_device_info(&id).await.ok()?;
+                Some(CentralEvent::DeviceDiscovered(device.mac_address.into()))
             }
-        }
-        BluetoothEvent::Device {
-            id,
-            event: DeviceEvent::Rssi { rssi: _ },
-        } => {
-            let device = session.get_device_info(&id).await.ok()?;
-            Some(CentralEvent::DeviceUpdated(device.mac_address.into()))
-        }
-        BluetoothEvent::Device {
-            id,
-            event: DeviceEvent::ManufacturerData { manufacturer_data },
-        } => {
-            let device = session.get_device_info(&id).await.ok()?;
-            Some(CentralEvent::ManufacturerDataAdvertisement {
-                id: device.mac_address.into(),
-                manufacturer_data,
-            })
-        }
-        BluetoothEvent::Device {
-            id,
-            event: DeviceEvent::ServiceData { service_data },
-        } => {
-            let device = session.get_device_info(&id).await.ok()?;
-            Some(CentralEvent::ServiceDataAdvertisement {
-                id: device.mac_address.into(),
-                service_data,
-            })
-        }
-        BluetoothEvent::Device {
-            id,
-            event: DeviceEvent::Services { services },
-        } => {
-            let device = session.get_device_info(&id).await.ok()?;
-            Some(CentralEvent::ServicesAdvertisement {
-                id: device.mac_address.into(),
-                services,
-            })
-        }
+            DeviceEvent::Connected { connected } => {
+                let device = session.get_device_info(&id).await.ok()?;
+                if connected {
+                    Some(CentralEvent::DeviceConnected(device.mac_address.into()))
+                } else {
+                    Some(CentralEvent::DeviceDisconnected(device.mac_address.into()))
+                }
+            }
+            DeviceEvent::Rssi { rssi: _ } => {
+                let device = session.get_device_info(&id).await.ok()?;
+                Some(CentralEvent::DeviceUpdated(device.mac_address.into()))
+            }
+            DeviceEvent::ManufacturerData { manufacturer_data } => {
+                let device = session.get_device_info(&id).await.ok()?;
+                Some(CentralEvent::ManufacturerDataAdvertisement {
+                    id: device.mac_address.into(),
+                    manufacturer_data,
+                })
+            }
+            DeviceEvent::ServiceData { service_data } => {
+                let device = session.get_device_info(&id).await.ok()?;
+                Some(CentralEvent::ServiceDataAdvertisement {
+                    id: device.mac_address.into(),
+                    service_data,
+                })
+            }
+            DeviceEvent::Services { services } => {
+                let device = session.get_device_info(&id).await.ok()?;
+                Some(CentralEvent::ServicesAdvertisement {
+                    id: device.mac_address.into(),
+                    services,
+                })
+            }
+            _ => None,
+        },
         _ => None,
     }
 }


### PR DESCRIPTION
This will be a bit nicer once https://github.com/bluez-rs/bluez-async/pull/20 is in.

Fixes the second issue found while investigating #241.