### PR TITLE
build: bump `dashmap` version to `5.1.0` and resolve `RUSTSEC-2022-0002`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ thiserror = "1.0.30"
 uuid = "0.8.2"
 serde_cr = { package = "serde", version = "1.0.133", features = ["derive"], default-features = false, optional = true }
 serde_bytes = { version = "0.11.5", optional = true }
-dashmap = "5.0.0"
+dashmap = "5.1.0"
 futures = "0.3.19"
 static_assertions = "1.1.0"
 tokio = { version = "1.15.0", features = ["rt", "sync"] }
@@ -54,4 +54,3 @@ rand = "0.8.4"
 pretty_env_logger = "0.4.0"
 tokio = { version = "1.15.0", features = ["macros", "rt", "rt-multi-thread"] }
 serde_json = "1.0.74"
-


### PR DESCRIPTION
The [RUSTSEC-2022-0002](https://rustsec.org/advisories/RUSTSEC-2022-0002.html) advisory identifies a memory vulnerability in version `5.0.0` of the [`dashmap`](https://crates.io/crates/dashmap) crate.

This vulnerability has been resolved in `dashmap 5.1.0`

More information:

* https://github.com/xacrimon/dashmap/issues/167
* https://github.com/xacrimon/dashmap/pull/180