### PR TITLE
fix: delegate_class panic for multiple calls

### DIFF
--- a/src/corebluetooth/central_delegate.rs
+++ b/src/corebluetooth/central_delegate.rs
@@ -246,9 +246,8 @@ pub mod CentralDelegate {
     fn delegate_class() -> &'static Class {
         trace!("delegate_class");
         static REGISTER_DELEGATE_CLASS: Once = Once::new();
-        let mut decl = ClassDecl::new("BtlePlugCentralManagerDelegate", class!(NSObject)).unwrap();
-
         REGISTER_DELEGATE_CLASS.call_once(|| {
+            let mut decl = ClassDecl::new("BtlePlugCentralManagerDelegate", class!(NSObject)).unwrap();
             decl.add_protocol(Protocol::get("CBCentralManagerDelegate").unwrap());
 
             decl.add_ivar::<*mut c_void>(DELEGATE_SENDER_IVAR); /* crossbeam_channel::Sender<DelegateMessage>* */


### PR DESCRIPTION
This PR fixes https://github.com/deviceplug/btleplug/issues/252 .

Calling `Manager::adapters()` twice should not panic the program. I believe it should be part of the `REGISTER_DELEGATE_CLASS` initialization block so that it will only be created once.