### PR TITLE
Implement disconnect for CoreBluetooth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.10.1 (2022-09-18)
+
+## Features
+
+- Add ability to disconnect devices on macOS/iOS
+
 # 0.10.0 (2022-07-30)
 
 ## Features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "btleplug"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["Nonpolynomial, LLC <kyle@nonpolynomial.com>"]
 license = "MIT/Apache-2.0/BSD-3-Clause"
 repository = "https://github.com/deviceplug/btleplug"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,18 +23,18 @@ path = "src/lib.rs"
 serde = ["uuid/serde", "serde_cr", "serde_bytes"]
 
 [dependencies]
-async-trait = "0.1.56"
+async-trait = "0.1.57"
 log = "0.4.17"
 bitflags = "1.3.2"
-thiserror = "1.0.31"
+thiserror = "1.0.35"
 uuid = "1.1.2"
-serde_cr = { package = "serde", version = "1.0.140", features = ["derive"], default-features = false, optional = true }
-serde_bytes = { version = "0.11.6", optional = true }
-dashmap = "5.3.4"
-futures = "0.3.21"
+serde_cr = { package = "serde", version = "1.0.144", features = ["derive"], default-features = false, optional = true }
+serde_bytes = { version = "0.11.7", optional = true }
+dashmap = "5.4.0"
+futures = "0.3.24"
 static_assertions = "1.1.0"
-tokio = { version = "1.20.1", features = ["rt", "sync"] }
-tokio-stream = { version = "0.1.9", features = ["sync"] }
+tokio = { version = "1.21.1", features = ["rt", "sync"] }
+tokio-stream = { version = "0.1.10", features = ["sync"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 dbus = "0.9.6"
@@ -42,19 +42,19 @@ bluez-async = "0.6.0"
 
 [target.'cfg(target_os = "android")'.dependencies]
 jni = "0.19.0"
-once_cell = "1.13.0"
+once_cell = "1.14.0"
 jni-utils = "0.1.0"
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 cocoa = "0.24.0"
 objc = "0.2.7"
-libc = "0.2.126"
+libc = "0.2.132"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows = { version = "0.39.0", features = ["Devices_Bluetooth", "Devices_Bluetooth_GenericAttributeProfile", "Devices_Bluetooth_Advertisement", "Devices_Radios", "Foundation_Collections", "Foundation", "Storage_Streams"] }
+windows = { version = "0.40.0", features = ["Devices_Bluetooth", "Devices_Bluetooth_GenericAttributeProfile", "Devices_Bluetooth_Advertisement", "Devices_Radios", "Foundation_Collections", "Foundation", "Storage_Streams"] }
 
 [dev-dependencies]
 rand = "0.8.5"
 pretty_env_logger = "0.4.0"
-tokio = { version = "1.20.1", features = ["macros", "rt", "rt-multi-thread"] }
-serde_json = "1.0.82"
+tokio = { version = "1.21.1", features = ["macros", "rt", "rt-multi-thread"] }
+serde_json = "1.0.85"

--- a/README.md
+++ b/README.md
@@ -107,7 +107,10 @@ A quick overview of the build process:
 
 ### iOS
 
-As the Corebluetooth implemenation is shared between macOS and iOS, btleplug on iOS should "just work", and seems to be stable. How this is built can vary based on your app setup and what language you're binding to, but sample instructions are as follows ([taken from here](https://github.com/deviceplug/btleplug/issues/12#issuecomment-1007671555)):
+As the Corebluetooth implementation is shared between macOS and iOS, btleplug on iOS should "just
+work", and seems to be stable. How this is built can vary based on your app setup and what language
+you're binding to, but sample instructions are as follows ([taken from
+here](https://github.com/deviceplug/btleplug/issues/12#issuecomment-1007671555)):
 
 - Write a rust library (static) that uses btleplug and exposes an FFI API to C
 - Use cbindgen to generate a C header file for that API

--- a/src/corebluetooth/internal.rs
+++ b/src/corebluetooth/internal.rs
@@ -140,6 +140,7 @@ struct CBPeripheral {
     pub peripheral: StrongPtr,
     services: HashMap<Uuid, ServiceInternal>,
     pub event_sender: Sender<CBPeripheralEvent>,
+    pub disconnected_future_state: Option<CoreBluetoothReplyStateShared>,
     pub connected_future_state: Option<CoreBluetoothReplyStateShared>,
 }
 
@@ -168,6 +169,7 @@ impl CBPeripheral {
             services: HashMap::new(),
             event_sender,
             connected_future_state: None,
+            disconnected_future_state: None,
         }
     }
 
@@ -228,6 +230,15 @@ impl CBPeripheral {
                 .unwrap()
                 .set_reply(CoreBluetoothReply::Connected(services));
         }
+    }
+
+    pub fn confirm_disconnect(&mut self) {
+        self.disconnected_future_state
+            .take()
+            .unwrap()
+            .lock()
+            .unwrap()
+            .set_reply(CoreBluetoothReply::Ok);
     }
 }
 
@@ -477,11 +488,30 @@ impl CoreBluetoothInternal {
         // itself when it receives all of its service/characteristic info.
     }
 
-    async fn on_peripheral_disconnect(&mut self, uuid: Uuid) {
+    async fn on_peripheral_disconnect(&mut self, peripheral_uuid: Uuid) {
         trace!("Got disconnect event!");
-        self.peripherals.remove(&uuid);
-        self.dispatch_event(CoreBluetoothEvent::DeviceDisconnected { uuid })
+        if self.peripherals.contains_key(&peripheral_uuid) {
+            if let Err(e) = self.peripherals
+                .get_mut(&peripheral_uuid)
+                .expect("If we're here we should have an ID")
+                .event_sender
+                .send(CBPeripheralEvent::Disconnected)
+                .await
+            {
+                error!("Error sending notification event: {}", e);
+            }
+            // Unlike connect, we'll want to fulfill our disconnect future here, which means grabbing
+            // our peripheral and having it fire, then dropping it and dispatching our event.
+            self.peripherals
+                .get_mut(&peripheral_uuid)
+                .expect("If we're here we should have an ID")
+                .confirm_disconnect();
+            self.peripherals.remove(&peripheral_uuid);
+            self.dispatch_event(CoreBluetoothEvent::DeviceDisconnected {
+                uuid: peripheral_uuid,
+            })
             .await;
+        }
     }
 
     /// Get the CBCharacteristic for the given characteristic of the given peripheral, if it exists.
@@ -589,6 +619,15 @@ impl CoreBluetoothInternal {
             trace!("Connecting peripheral!");
             p.connected_future_state = Some(fut);
             cb::centralmanager_connectperipheral(*self.manager, *p.peripheral);
+        }
+    }
+
+    fn disconnect_peripheral(&mut self, peripheral_uuid: Uuid, fut: CoreBluetoothReplyStateShared) {
+        trace!("Trying to disconnect peripheral!");
+        if let Some(p) = self.peripherals.get_mut(&peripheral_uuid) {
+            trace!("Disconnecting peripheral!");
+            p.disconnected_future_state = Some(fut);
+            cb::centralmanager_cancelperipheralconnection(*self.manager, *p.peripheral);
         }
     }
 
@@ -774,7 +813,9 @@ impl CoreBluetoothInternal {
                         trace!("got connectdevice msg!");
                         self.connect_peripheral(peripheral_uuid, future);
                     }
-                    CoreBluetoothMessage::DisconnectDevice{peripheral_uuid:_, future:_} => {}
+                    CoreBluetoothMessage::DisconnectDevice{peripheral_uuid, future} => {
+                        self.disconnect_peripheral(peripheral_uuid, future);
+                    }
                     CoreBluetoothMessage::ReadValue{peripheral_uuid, service_uuid,characteristic_uuid, future} => {
                         self.read_value(peripheral_uuid, service_uuid,characteristic_uuid, future)
                     }

--- a/src/corebluetooth/internal.rs
+++ b/src/corebluetooth/internal.rs
@@ -491,7 +491,8 @@ impl CoreBluetoothInternal {
     async fn on_peripheral_disconnect(&mut self, peripheral_uuid: Uuid) {
         trace!("Got disconnect event!");
         if self.peripherals.contains_key(&peripheral_uuid) {
-            if let Err(e) = self.peripherals
+            if let Err(e) = self
+                .peripherals
                 .get_mut(&peripheral_uuid)
                 .expect("If we're here we should have an ID")
                 .event_sender

--- a/src/corebluetooth/peripheral.rs
+++ b/src/corebluetooth/peripheral.rs
@@ -258,7 +258,7 @@ impl api::Peripheral for Peripheral {
             CoreBluetoothReply::Ok => {
                 self.shared
                     .emit_event(CentralEvent::DeviceDisconnected(self.shared.uuid.into()));
-                trace!("Device disconnected!");                    
+                trace!("Device disconnected!");
             }
             _ => error!("Shouldn't get anything but Ok!"),
         }


### PR DESCRIPTION
Implementing disconnect for CoreBluetooth. Pretty much just glue code for CB calls that were already in the library.

@qwandor Reviewing mostly as ritual/habit here, can't remember how familiar you are with the CB stuff, so nbd if you aren't up to reviewing it. I've done some cursory testing with this on iOS and it seems happy.

I need this for my upcoming mobile app release so hoping to land/release soon.