### PR TITLE
Make peripheral id field public

### DIFF
--- a/src/bluez/peripheral.rs
+++ b/src/bluez/peripheral.rs
@@ -32,7 +32,7 @@ struct ServiceInternal {
     serde(crate = "serde_cr")
 )]
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct PeripheralId(pub(crate) DeviceId);
+pub struct PeripheralId(pub DeviceId);
 
 /// Implementation of [api::Peripheral](crate::api::Peripheral).
 #[derive(Clone, Debug)]

--- a/src/corebluetooth/peripheral.rs
+++ b/src/corebluetooth/peripheral.rs
@@ -45,7 +45,7 @@ use uuid::Uuid;
     serde(crate = "serde_cr")
 )]
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct PeripheralId(Uuid);
+pub struct PeripheralId(pub Uuid);
 
 /// Implementation of [api::Peripheral](crate::api::Peripheral).
 #[derive(Clone)]

--- a/src/winrtble/peripheral.rs
+++ b/src/winrtble/peripheral.rs
@@ -52,7 +52,7 @@ use windows::Devices::Bluetooth::{Advertisement::*, BluetoothAddressType};
     serde(crate = "serde_cr")
 )]
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct PeripheralId(BDAddr);
+pub struct PeripheralId(pub BDAddr);
 
 /// Implementation of [api::Peripheral](crate::api::Peripheral).
 #[derive(Clone)]


### PR DESCRIPTION
I need to access this field for my project. I don't see any disadvantage in making it public.

Thanks for making and supporting this crate :) 