### PR TITLE
Implement Display for PeripheralId

### DIFF
--- a/src/bluez/adapter.rs
+++ b/src/bluez/adapter.rs
@@ -1,5 +1,5 @@
 use super::peripheral::{Peripheral, PeripheralId};
-use crate::api::{BDAddr, Central, CentralEvent, ScanFilter};
+use crate::api::{Central, CentralEvent, ScanFilter};
 use crate::{Error, Result};
 use async_trait::async_trait;
 use bluez_async::{

--- a/src/bluez/peripheral.rs
+++ b/src/bluez/peripheral.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "serde")]
 use serde_cr as serde;
 use std::collections::{BTreeSet, HashMap};
+use std::fmt::{self, Display, Formatter};
 use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 use uuid::Uuid;
@@ -33,6 +34,12 @@ struct ServiceInternal {
 )]
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct PeripheralId(pub(crate) DeviceId);
+
+impl Display for PeripheralId {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
 
 /// Implementation of [api::Peripheral](crate::api::Peripheral).
 #[derive(Clone, Debug)]

--- a/src/corebluetooth/adapter.rs
+++ b/src/corebluetooth/adapter.rs
@@ -1,6 +1,6 @@
 use super::internal::{run_corebluetooth_thread, CoreBluetoothEvent, CoreBluetoothMessage};
 use super::peripheral::{Peripheral, PeripheralId};
-use crate::api::{BDAddr, Central, CentralEvent, ScanFilter};
+use crate::api::{Central, CentralEvent, ScanFilter};
 use crate::common::adapter_manager::AdapterManager;
 use crate::{Error, Result};
 use async_trait::async_trait;

--- a/src/corebluetooth/peripheral.rs
+++ b/src/corebluetooth/peripheral.rs
@@ -47,6 +47,12 @@ use uuid::Uuid;
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct PeripheralId(Uuid);
 
+impl Display for PeripheralId {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        Display::fmt(&self.0, f)
+    }
+}
+
 /// Implementation of [api::Peripheral](crate::api::Peripheral).
 #[derive(Clone)]
 pub struct Peripheral {

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -20,7 +20,10 @@ pub use crate::winrtble::{
 
 use crate::api::{self, Central};
 use static_assertions::assert_impl_all;
-use std::{fmt::Debug, hash::Hash};
+use std::{
+    fmt::{Debug, Display},
+    hash::Hash,
+};
 
 // Ensure that the exported types implement all the expected traits.
 assert_impl_all!(Adapter: Central, Clone, Debug, Send, Sized, Sync);
@@ -29,6 +32,7 @@ assert_impl_all!(Peripheral: api::Peripheral, Clone, Debug, Send, Sized, Sync);
 assert_impl_all!(
     PeripheralId: Clone,
     Debug,
+    Display,
     Hash,
     Eq,
     Ord,

--- a/src/winrtble/peripheral.rs
+++ b/src/winrtble/peripheral.rs
@@ -54,6 +54,12 @@ use windows::Devices::Bluetooth::{Advertisement::*, BluetoothAddressType};
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct PeripheralId(BDAddr);
 
+impl Display for PeripheralId {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        Display::fmt(&self.0, f)
+    }
+}
+
 /// Implementation of [api::Peripheral](crate::api::Peripheral).
 #[derive(Clone)]
 pub struct Peripheral {


### PR DESCRIPTION
This lets clients render the `PeripheralId` in some platform-specific way for users to distinguish devices, without exposing the internal representation to the API as #266 proposed to do.