### PR TITLE
Resolving an issue with local_name being blank on Windows 11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ objc = "0.2.7"
 libc = "0.2.133"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows = { version = "0.41.0", features = ["Devices_Bluetooth", "Devices_Bluetooth_GenericAttributeProfile", "Devices_Bluetooth_Advertisement", "Devices_Radios", "Foundation_Collections", "Foundation", "Storage_Streams"] }
+windows = { version = "0.42.0", features = ["Devices_Bluetooth", "Devices_Bluetooth_GenericAttributeProfile", "Devices_Bluetooth_Advertisement", "Devices_Radios", "Foundation_Collections", "Foundation", "Storage_Streams"] }
 
 [dev-dependencies]
 rand = "0.8.5"


### PR DESCRIPTION
Hi, and thanks for this excellent BLE library!

On Windows 11, there is an issue with `local_name` not being populated at device scan time. This seems to be because Windows devices possibly do not observe the `local_name` property in the advertisement packet.

This PR resolves the issue by calling `BluetoothLEDevice::FromBluetoothAddressAsync` to specifically retrieve the `local_name` for the device in question. In my testing, the `local_name` property is now set 100% of the time at device discovery.

However - the `BluetoothLEDevice::FromBluetoothAddressAsync` call is *async* while the `update_properties` function is *sync*. Because this call is also implemented on other platforms, I've decided to block on this call until it returns, so we don't have to make this function async, and then make all the other implementations async as well.

Also, I started learning rust 2 weeks ago, so my code may be overly verbose, or this might just be a non-smart suggestion, so forgive any weirdness or lame ideas in the PR. Thanks for reviewing!