### PR TITLE
CoreBluetooth: skip fulfilling disconnect future if not present

### DIFF
--- a/src/corebluetooth/internal.rs
+++ b/src/corebluetooth/internal.rs
@@ -233,12 +233,14 @@ impl CBPeripheral {
     }
 
     pub fn confirm_disconnect(&mut self) {
-        self.disconnected_future_state
-            .take()
-            .unwrap()
-            .lock()
-            .unwrap()
-            .set_reply(CoreBluetoothReply::Ok);
+        // Fulfill the disconnected future, if there is one.
+        // There might not be a future if the device disconnects unexpectedly.
+        if let Some(future) = self.disconnected_future_state.take() {
+            future
+                .lock()
+                .unwrap()
+                .set_reply(CoreBluetoothReply::Ok)
+        }
     }
 }
 

--- a/src/corebluetooth/internal.rs
+++ b/src/corebluetooth/internal.rs
@@ -236,10 +236,7 @@ impl CBPeripheral {
         // Fulfill the disconnected future, if there is one.
         // There might not be a future if the device disconnects unexpectedly.
         if let Some(future) = self.disconnected_future_state.take() {
-            future
-                .lock()
-                .unwrap()
-                .set_reply(CoreBluetoothReply::Ok)
+            future.lock().unwrap().set_reply(CoreBluetoothReply::Ok)
         }
     }
 }


### PR DESCRIPTION
When a device disconnects, the `on_peripheral_disconnect` handler fires, which tries to fulfill a future for an awaiting call to `disconnect_peripheral`.

However, a device may disconnect for reasons other than a call to `disconnect_peripheral`. In this case there is no future to fulfill. This leads a panic when unwrapping `disconnected_future_state` in `confirm_disconnect`.
This appears to be the cause of issues #273, #270 and possibly #271.

This change skips fulfilling the future if there is none, to avoid this panic. (The disconnect notification will still fire.)

This seems to work well in my testing, but I'm not familiar with the architecture of btleplug so this may not be the right approach.