### PR TITLE
Set the "connected" state to false when disconnecting on Windows.

### DIFF
--- a/src/winrtble/peripheral.rs
+++ b/src/winrtble/peripheral.rs
@@ -390,6 +390,7 @@ impl ApiPeripheral for Peripheral {
     async fn disconnect(&self) -> Result<()> {
         let mut device = self.shared.device.lock().await;
         *device = None;
+        self.shared.connected.store(false, Ordering::Relaxed);
         self.emit_event(CentralEvent::DeviceDisconnected(self.shared.address.into()));
         Ok(())
     }


### PR DESCRIPTION
After disconnecting from a peripheral with `device.disconnect()` on Windows, `device.is_connected()` still returned `true`. The disconnect event always happened. Only the state was not reflected correctly.

Tested successfully on Windows 11.

This bug is also mentioned in issue #212.