### PR TITLE
Improve error propagation in manager.adapters() on Windows.

### DIFF
--- a/src/winrtble/manager.rs
+++ b/src/winrtble/manager.rs
@@ -31,15 +31,12 @@ impl api::Manager for Manager {
     type Adapter = Adapter;
 
     async fn adapters(&self) -> Result<Vec<Adapter>> {
-        let mut result: Vec<Adapter> = vec![];
-        let radios = Radio::GetRadiosAsync().unwrap().await.unwrap();
-
-        for radio in &radios {
-            let kind = radio.Kind().unwrap();
-            if kind == RadioKind::Bluetooth {
-                result.push(Adapter::new());
-            }
-        }
-        return Ok(result);
+        let radios = Radio::GetRadiosAsync()?.await?;
+        Ok(radios
+            .into_iter()
+            .filter_map(|radio| radio.Kind().ok())
+            .filter(|&kind| kind == RadioKind::Bluetooth)
+            .map(|_| Adapter::new())
+            .collect())
     }
 }


### PR DESCRIPTION
Replace some occurrences of `.unwrap()` with `?` to prevent panics when `Radio::GetRadiosAsync()` fails.
Radios where `radio.Kind()` fails are skipped. I hope that behavior is acceptable.

Problem is mentioned in issue #212.