### PR TITLE
Set `DuplicateData = true` for bluez

### DIFF
--- a/src/bluez/adapter.rs
+++ b/src/bluez/adapter.rs
@@ -59,6 +59,7 @@ impl Central for Adapter {
     async fn start_scan(&self, filter: ScanFilter) -> Result<()> {
         let filter = DiscoveryFilter {
             service_uuids: filter.services,
+            duplicate_data: Some(true),
             transport: Some(Transport::Auto),
             ..Default::default()
         };


### PR DESCRIPTION
Fixes #289

This makes bluez discovery work like it does on macOS and Windows.