### PR TITLE
Add RSSI support to CoreBluetooth

### DIFF
--- a/src/corebluetooth/adapter.rs
+++ b/src/corebluetooth/adapter.rs
@@ -47,6 +47,7 @@ impl Adapter {
                         uuid,
                         name,
                         event_receiver,
+                        rssi,
                     } => {
                         manager_clone.add_peripheral(Peripheral::new(
                             uuid,
@@ -54,6 +55,7 @@ impl Adapter {
                             Arc::downgrade(&manager_clone),
                             event_receiver,
                             adapter_sender_clone.clone(),
+                            Some(rssi),
                         ));
                         manager_clone.emit(CentralEvent::DeviceDiscovered(uuid.into()));
                     }

--- a/src/corebluetooth/central_delegate.rs
+++ b/src/corebluetooth/central_delegate.rs
@@ -51,6 +51,7 @@ pub enum CentralDelegateEvent {
     DidUpdateState,
     DiscoveredPeripheral {
         cbperipheral: StrongPtr,
+        rssi: i16,
     },
     DiscoveredServices {
         peripheral_uuid: Uuid,
@@ -112,9 +113,10 @@ impl Debug for CentralDelegateEvent {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match self {
             CentralDelegateEvent::DidUpdateState => f.debug_tuple("DidUpdateState").finish(),
-            CentralDelegateEvent::DiscoveredPeripheral { cbperipheral } => f
+            CentralDelegateEvent::DiscoveredPeripheral { cbperipheral, rssi } => f
                 .debug_struct("CentralDelegateEvent")
                 .field("cbperipheral", cbperipheral.deref())
+                .field("rssi", rssi)
                 .finish(),
             CentralDelegateEvent::DiscoveredServices {
                 peripheral_uuid,
@@ -413,7 +415,7 @@ pub mod CentralDelegate {
         _central: id,
         peripheral: id,
         adv_data: id,
-        _rssi: id,
+        rssi: id,
     ) {
         trace!(
             "delegate_centralmanager_diddiscoverperipheral_advertisementdata_rssi {}",
@@ -425,6 +427,7 @@ pub mod CentralDelegate {
             delegate,
             CentralDelegateEvent::DiscoveredPeripheral {
                 cbperipheral: held_peripheral,
+                rssi: ns::nsnumber_i16(rssi),
             },
         );
 

--- a/src/corebluetooth/framework.rs
+++ b/src/corebluetooth/framework.rs
@@ -33,6 +33,14 @@ pub mod ns {
         unsafe { msg_send![class!(NSNumber), numberWithBool: value] }
     }
 
+    pub fn nsnumber_i32(nsnumber: id) -> i32 {
+        unsafe { msg_send![nsnumber, intValue] }
+    }
+
+    pub fn nsnumber_i16(nsnumber: id) -> i16 {
+        ns::nsnumber_i32(nsnumber) as i16
+    }
+
     // NSArray
 
     pub fn array_count(nsarray: impl NSArray) -> NSUInteger {

--- a/src/corebluetooth/peripheral.rs
+++ b/src/corebluetooth/peripheral.rs
@@ -89,6 +89,7 @@ impl Peripheral {
         manager: Weak<AdapterManager<Self>>,
         event_receiver: Receiver<CBPeripheralEvent>,
         message_sender: Sender<CoreBluetoothMessage>,
+        rssi: Option<i16>,
     ) -> Self {
         // Since we're building the object, we have an active advertisement.
         // Build properties now.
@@ -97,7 +98,7 @@ impl Peripheral {
             address_type: None,
             local_name,
             tx_power_level: None,
-            rssi: None,
+            rssi,
             manufacturer_data: HashMap::new(),
             service_data: HashMap::new(),
             services: Vec::new(),


### PR DESCRIPTION
This adds support for RSSI to CoreBluetooth.
Please let me know if it need changes, happy to do it.
Tested on Mac, not on iOS.