### PR TITLE
add: PeripheralId <-> Uuid conversion for macos

### DIFF
--- a/src/corebluetooth/peripheral.rs
+++ b/src/corebluetooth/peripheral.rs
@@ -382,6 +382,12 @@ impl From<Uuid> for PeripheralId {
     }
 }
 
+impl From<PeripheralId> for Uuid {
+		fn from(id: PeripheralId) -> Self {
+				id.0
+		}
+}
+
 impl From<SendError> for Error {
     fn from(_: SendError) -> Self {
         Error::Other("Channel closed".to_string().into())


### PR DESCRIPTION
I need to have a cross-platform way of serialising a PeripheralId (or equivalent structure),
so that I can have some identity to the BLE devices I am connecting to.

I am building a front-end to consume connection states.