### PR TITLE
added request_mtu function for android Peripheral

### DIFF
--- a/src/droidplug/java/src/main/java/com/nonpolynomial/btleplug/android/impl/Peripheral.java
+++ b/src/droidplug/java/src/main/java/com/nonpolynomial/btleplug/android/impl/Peripheral.java
@@ -85,11 +85,11 @@ class Peripheral {
     }
 
     
-    public void requestMtu() {
+    public void requestMtu(int mtu) {
         synchronized (this) {
             if (this.gatt != null) {
                 try {
-                    this.gatt.requestMtu(517);
+                    this.gatt.requestMtu(mtu);
                 } catch (Exception e) {
                     Log.e("Droidplug", "error requesting mtu: " + e.toString());
                 }

--- a/src/droidplug/java/src/main/java/com/nonpolynomial/btleplug/android/impl/Peripheral.java
+++ b/src/droidplug/java/src/main/java/com/nonpolynomial/btleplug/android/impl/Peripheral.java
@@ -20,6 +20,8 @@ import io.github.gedgygedgy.rust.stream.QueueStream;
 import io.github.gedgygedgy.rust.future.SimpleFuture;
 import io.github.gedgygedgy.rust.stream.Stream;
 
+import android.util.Log;
+
 @SuppressWarnings("unused") // Native code uses this class.
 class Peripheral {
     private static final UUID CLIENT_CHARACTERISTIC_CONFIGURATION_DESCRIPTOR = new UUID(0x00002902_0000_1000L, 0x8000_00805f9b34fbL);
@@ -81,6 +83,20 @@ class Peripheral {
         }
         return future;
     }
+
+    
+    public void requestMtu() {
+        synchronized (this) {
+            if (this.gatt != null) {
+                try {
+                    this.gatt.requestMtu(517);
+                } catch (Exception e) {
+                    Log.e("Droidplug", "error requesting mtu: " + e.toString());
+                }
+            }
+        }
+    }
+                    
 
     public Future<Void> disconnect() {
         SimpleFuture<Void> future = new SimpleFuture<>();

--- a/src/droidplug/jni/objects.rs
+++ b/src/droidplug/jni/objects.rs
@@ -15,6 +15,7 @@ use crate::api::{BDAddr, CharPropFlags, PeripheralProperties};
 pub struct JPeripheral<'a: 'b, 'b> {
     internal: JObject<'a>,
     connect: JMethodID<'a>,
+    request_mtu: JMethodID<'a>,
     disconnect: JMethodID<'a>,
     is_connected: JMethodID<'a>,
     discover_services: JMethodID<'a>,
@@ -59,6 +60,7 @@ impl<'a: 'b, 'b> JPeripheral<'a, 'b> {
             "connect",
             "()Lio/github/gedgygedgy/rust/future/Future;",
         )?;
+        let request_mtu = env.get_method_id(class, "requestMtu", "()V")?;
         let disconnect = env.get_method_id(
             class,
             "disconnect",
@@ -93,6 +95,7 @@ impl<'a: 'b, 'b> JPeripheral<'a, 'b> {
         Ok(Self {
             internal: obj,
             connect,
+            request_mtu,
             disconnect,
             is_connected,
             discover_services,
@@ -134,6 +137,18 @@ impl<'a: 'b, 'b> JPeripheral<'a, 'b> {
             )?
             .l()?;
         JFuture::from_env(self.env, future_obj)
+    }
+
+    pub fn request_mtu(&self) -> Result<()> {
+        self.env
+            .call_method_unchecked(
+                self.internal,
+                self.request_mtu,
+                JavaType::Primitive(Primitive::Void),
+                &[],
+            )?
+            .v()?;
+        Ok(())
     }
 
     pub fn disconnect(&self) -> Result<JFuture<'a, 'b>> {

--- a/src/droidplug/jni/objects.rs
+++ b/src/droidplug/jni/objects.rs
@@ -60,7 +60,7 @@ impl<'a: 'b, 'b> JPeripheral<'a, 'b> {
             "connect",
             "()Lio/github/gedgygedgy/rust/future/Future;",
         )?;
-        let request_mtu = env.get_method_id(class, "requestMtu", "()V")?;
+        let request_mtu = env.get_method_id(class, "requestMtu", "(I)V")?;
         let disconnect = env.get_method_id(
             class,
             "disconnect",
@@ -139,13 +139,13 @@ impl<'a: 'b, 'b> JPeripheral<'a, 'b> {
         JFuture::from_env(self.env, future_obj)
     }
 
-    pub fn request_mtu(&self) -> Result<()> {
+    pub fn request_mtu(&self, mtu: i32) -> Result<()> {
         self.env
             .call_method_unchecked(
                 self.internal,
                 self.request_mtu,
                 JavaType::Primitive(Primitive::Void),
-                &[],
+                &[mtu.into()],
             )?
             .v()?;
         Ok(())

--- a/src/droidplug/peripheral.rs
+++ b/src/droidplug/peripheral.rs
@@ -130,6 +130,10 @@ impl Peripheral {
             get_poll_result(env, result).map(|_| {})
         })
     }
+
+    pub async fn request_mtu(&self) -> Result<()> {
+        self.with_obj(|_env, obj| Ok(obj.request_mtu()?))
+    }
 }
 
 impl Debug for Peripheral {

--- a/src/droidplug/peripheral.rs
+++ b/src/droidplug/peripheral.rs
@@ -131,8 +131,8 @@ impl Peripheral {
         })
     }
 
-    pub async fn request_mtu(&self) -> Result<()> {
-        self.with_obj(|_env, obj| Ok(obj.request_mtu()?))
+    pub async fn request_mtu(&self, mtu: i32) -> Result<()> {
+        self.with_obj(|_env, obj| Ok(obj.request_mtu(mtu)?))
     }
 }
 


### PR DESCRIPTION
I implemented a request_mtu function that simply requests the maximum mtu on Android. In my case I used it as follows
```rs
#[cfg(target_os = "android")]
{
    peripheral.request_mtu().await?;
}
```
Actually, the function should be implemented as a future waiting for the [onMtuChanged callback](https://developer.android.com/reference/android/bluetooth/BluetoothGattCallback#onMtuChanged(android.bluetooth.BluetoothGatt,%20int,%20int)), but I couldn't get that to work.
The callback was never called on the android side. My data rate was much higher after the request_mtu call, so the mtu was still set.

I wanted to open this PR anyway because this change made the library usable for my project. Without this change, it can't be used on Android if you need a certain data throughput.

Maybe someone with more knowledge about android can improve this, but it is a working basis.