### PR TITLE
fix CBManager crash on macOS `<10.15` (#335)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ bluez-async = "0.7.2"
 jni = "0.19.0"
 once_cell = "1.18.0"
 jni-utils = "0.1.1"
+os_info = "3.7.0"
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 cocoa = "0.25.0"

--- a/src/corebluetooth/framework.rs
+++ b/src/corebluetooth/framework.rs
@@ -174,7 +174,13 @@ pub mod cb {
 
     // CBManager
     pub fn manager_authorization() -> CBManagerAuthorization {
-        unsafe { msg_send![class!(CBManager), authorization] }
+        use os_info::Version::Semantic as OSSemVer;
+
+        if os_info::get().version() >= &OSSemVer(10, 15, 0) {
+            unsafe { msg_send![class!(CBManager), authorization] }
+        } else {
+            CBManagerAuthorization::NotDetermined
+        }
     }
 
     #[derive(Copy, Clone, Debug, Eq, PartialEq)]


### PR DESCRIPTION
my current fix for the #335 issue I made