### PR TITLE
eliminate cargo clippy warnings

### DIFF
--- a/src/api/bdaddr.rs
+++ b/src/api/bdaddr.rs
@@ -106,7 +106,7 @@ impl TryFrom<u64> for BDAddr {
 impl From<BDAddr> for u64 {
     fn from(addr: BDAddr) -> Self {
         let mut slice = [0; 8];
-        (&mut slice[2..]).copy_from_slice(&addr.into_inner());
+        slice[2..].copy_from_slice(&addr.into_inner());
         u64::from_be_bytes(slice)
     }
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -48,19 +48,15 @@ use crate::platform::PeripheralId;
     derive(Serialize, Deserialize),
     serde(crate = "serde_cr")
 )]
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
 pub enum AddressType {
     Random,
+    #[default]
     Public,
 }
 
-impl Default for AddressType {
-    fn default() -> Self {
-        AddressType::Public
-    }
-}
-
 impl AddressType {
+    #[allow(clippy::should_implement_trait)]
     pub fn from_str(v: &str) -> Option<AddressType> {
         match v {
             "public" => Some(AddressType::Public),
@@ -93,8 +89,6 @@ pub struct ValueNotification {
     /// The new value of the characteristic.
     pub value: Vec<u8>,
 }
-
-
 
 bitflags! {
     /// A set of properties that indicate what operations are supported by a Characteristic.

--- a/src/bluez/peripheral.rs
+++ b/src/bluez/peripheral.rs
@@ -368,8 +368,8 @@ impl From<&ServiceInternal> for Service {
             primary: service.info.primary,
             characteristics: service
                 .characteristics
-                .iter()
-                .map(|(_, characteristic)| make_characteristic(characteristic, service.info.uuid))
+                .values()
+                .map(|characteristic| make_characteristic(characteristic, service.info.uuid))
                 .collect(),
         }
     }

--- a/src/common/util.rs
+++ b/src/common/util.rs
@@ -14,11 +14,5 @@ use tokio_stream::wrappers::BroadcastStream;
 pub fn notifications_stream_from_broadcast_receiver(
     receiver: Receiver<ValueNotification>,
 ) -> Pin<Box<dyn Stream<Item = ValueNotification> + Send>> {
-    Box::pin(BroadcastStream::new(receiver).filter_map(|x| async move {
-        if x.is_ok() {
-            Some(x.unwrap())
-        } else {
-            None
-        }
-    }))
+    Box::pin(BroadcastStream::new(receiver).filter_map(|x| async move { x.ok() }))
 }

--- a/src/winrtble/ble/characteristic.rs
+++ b/src/winrtble/ble/characteristic.rs
@@ -35,9 +35,9 @@ use windows::{
 
 pub type NotifiyEventHandler = Box<dyn Fn(Vec<u8>) + Send>;
 
-impl Into<GattWriteOption> for WriteType {
-    fn into(self) -> GattWriteOption {
-        match self {
+impl From<WriteType> for GattWriteOption {
+    fn from(val: WriteType) -> Self {
+        match val {
             WriteType::WithoutResponse => GattWriteOption::WriteWithoutResponse,
             WriteType::WithResponse => GattWriteOption::WriteWithResponse,
         }

--- a/src/winrtble/utils.rs
+++ b/src/winrtble/utils.rs
@@ -33,7 +33,7 @@ pub fn to_error(status: GattCommunicationStatus) -> Result<()> {
     } else if status == GattCommunicationStatus::ProtocolError {
         Err(Error::NotSupported("ProtocolError".to_string()))
     } else {
-        Err(Error::Other(format!("Communication Error:").into()))
+        Err(Error::Other("Communication Error:".to_string().into()))
     }
 }
 


### PR DESCRIPTION
Running cargo clippy generates a bunch of warnings which this commit resolves for both Windows and Linux:

```
$ cargo clippy
    Checking btleplug v0.11.1 (C:\Users\mamad\Desktop\dev\btleplug)
warning: redundant field names in struct initialization
  --> src\winrtble\peripheral.rs:93:17
   |
93 |                 adapter: adapter,
   |                 ^^^^^^^^^^^^^^^^ help: replace it with: `adapter`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_field_names
   = note: `#[warn(clippy::redundant_field_names)]` on by default

warning: redundant field names in struct initialization
  --> src\winrtble\peripheral.rs:95:17
   |
95 |                 address: address,
   |                 ^^^^^^^^^^^^^^^^ help: replace it with: `address`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_field_names

warning: redundant field names in struct initialization
   --> src\winrtble\peripheral.rs:502:56
    |
502 |                 let notification = ValueNotification { uuid: uuid, value };
    |                                                        ^^^^^^^^^^ help: replace it with: `uuid`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_field_names

warning: this expression borrows a value the compiler would automatically borrow
   --> src\api\bdaddr.rs:109:9
    |
109 |         (&mut slice[2..]).copy_from_slice(&addr.into_inner());
    |         ^^^^^^^^^^^^^^^^^ help: change this to: `slice[2..]`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow
    = note: `#[warn(clippy::needless_borrow)]` on by default

warning: this `impl` can be derived
  --> src\api\mod.rs:57:1
   |
57 | / impl Default for AddressType {
58 | |     fn default() -> Self {
59 | |         AddressType::Public
60 | |     }
61 | | }
   | |_^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#derivable_impls
   = note: `#[warn(clippy::derivable_impls)]` on by default
   = help: remove the manual implementation...
help: ...and instead derive it...
   |
52 + #[derive(Default)]
53 | pub enum AddressType {
   |
help: ...and mark the default variant
   |
54 ~     #[default]
55 ~     Public,
   |

warning: method `from_str` can be confused for the standard trait method `std::str::FromStr::from_str`
  --> src\api\mod.rs:64:5
   |
64 | /     pub fn from_str(v: &str) -> Option<AddressType> {
65 | |         match v {
66 | |             "public" => Some(AddressType::Public),
67 | |             "random" => Some(AddressType::Random),
68 | |             _ => None,
69 | |         }
70 | |     }
   | |_____^
   |
   = help: consider implementing the trait `std::str::FromStr` or choosing a less ambiguous method name
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#should_implement_trait
   = note: `#[warn(clippy::should_implement_trait)]` on by default

warning: you seem to be trying to use `match` for destructuring a single pattern. Consider using `if let`
  --> src\common\adapter_manager.rs:47:9
   |
47 | /         match event {
48 | |             CentralEvent::DeviceDisconnected(ref id) => {
49 | |                 self.peripherals.remove(id);
50 | |             }
51 | |             _ => {}
52 | |         }
   | |_________^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_match
   = note: `#[warn(clippy::single_match)]` on by default
help: try this
   |
47 ~         if let CentralEvent::DeviceDisconnected(ref id) = event {
48 +             self.peripherals.remove(id);
49 +         }
   |

warning: called `unwrap` on `x` after checking its variant with `is_ok`
  --> src\common\adapter_manager.rs:63:22
   |
62 |             if x.is_ok() {
   |             ------------ help: try: `if let Ok(..) = x`
63 |                 Some(x.unwrap())
   |                      ^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_unwrap
   = note: `#[warn(clippy::unnecessary_unwrap)]` on by default

warning: called `unwrap` on `x` after checking its variant with `is_ok`
  --> src\common\util.rs:19:18
   |
18 |         if x.is_ok() {
   |         ------------ help: try: `if let Ok(..) = x`
19 |             Some(x.unwrap())
   |                  ^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_unwrap

warning: an implementation of `From` is preferred since it gives you `Into<_>` for free where the reverse isn't true
  --> src\winrtble\ble\characteristic.rs:38:1
   |
38 | impl Into<GattWriteOption> for WriteType {
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: `impl From<Local> for Foreign` is allowed by the orphan rules, for more information see
           https://doc.rust-lang.org/reference/items/implementations.html#trait-implementation-coherence
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#from_over_into
   = note: `#[warn(clippy::from_over_into)]` on by default
help: replace the `Into` implementation with `From<api::WriteType>`
   |
38 ~ impl From<WriteType> for GattWriteOption {
39 ~     fn from(val: WriteType) -> Self {
40 ~         match val {
   |

warning: you are using an explicit closure for copying elements
   --> src\winrtble\peripheral.rs:122:23
    |
122 |               services: self
    |  _______________________^
123 | |                 .shared
124 | |                 .services
125 | |                 .read()
126 | |                 .unwrap()
127 | |                 .iter()
128 | |                 .map(|uuid| *uuid)
    | |__________________________________^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#map_clone
    = note: `#[warn(clippy::map_clone)]` on by default
help: consider calling the dedicated `copied` method
    |
122 ~             services: self
123 +                 .shared
124 +                 .services
125 +                 .read()
126 +                 .unwrap()
127 +                 .iter().copied()
    |

warning: using `clone` on type `Option<u32>` which implements the `Copy` trait
   --> src\winrtble\peripheral.rs:130:20
    |
130 |             class: self.shared.class.read().unwrap().clone(),
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try dereferencing it: `*self.shared.class.read().unwrap()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#clone_on_copy
    = note: `#[warn(clippy::clone_on_copy)]` on by default

warning: you are using an explicit closure for copying elements
   --> src\winrtble\peripheral.rs:254:31
    |
254 |                     services: services_guard.iter().map(|uuid| *uuid).collect(),
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider calling the dedicated `copied` method: `services_guard.iter().copied()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#map_clone

warning: this expression creates a reference which is immediately dereferenced by the compiler
   --> src\winrtble\peripheral.rs:412:58
    |
412 |                     match BLEDevice::get_characteristics(&service).await {
    |                                                          ^^^^^^^^ help: change this to: `service`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

warning: useless use of `format!`
  --> src\winrtble\utils.rs:36:26
   |
36 |         Err(Error::Other(format!("Communication Error:").into()))
   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using `.to_string()`: `"Communication Error:".to_string()`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_format
   = note: `#[warn(clippy::useless_format)]` on by default

warning: `btleplug` (lib) generated 15 warnings (run `cargo clippy --fix --lib -p btleplug` to apply 11 suggestions)
    Finished dev [unoptimized + debuginfo] target(s) in 0.72s
```