### PR TITLE
depend on vendored dbus in order to avoid build failure with libdbus-sys on linux aarch64 target

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ tokio = { version = "1.32.0", features = ["sync", "rt"] }
 tokio-stream = { version = "0.1.14", features = ["sync"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-dbus = "0.9.7"
+dbus = { version = "0.9.7", features = ["vendored"] }
 bluez-async = "0.7.2"
 
 [target.'cfg(target_os = "android")'.dependencies]


### PR DESCRIPTION
Cross-compiling for Linux AArch64 fails due to libdbus-sys native library dependency. As stated in the [dbus-rs compilation guide](https://github.com/diwic/dbus-rs/blob/master/libdbus-sys/cross_compile.md) there are three ways to resolve this issue. The simplest one would be:

```
dbus = {version = "0.9.7", features = ["vendored"]}
```

Otherwise, when cross-compiling for AArch64 from a x86-64 Linux host, the user gets:

```
   Compiling proc-macro2 v1.0.69
   Compiling unicode-ident v1.0.12
   Compiling autocfg v1.1.0
   Compiling libc v0.2.150
   Compiling futures-core v0.3.29
   Compiling futures-sink v0.3.29
   Compiling pin-project-lite v0.2.13
   Compiling futures-channel v0.3.29
   Compiling futures-task v0.3.29
   Compiling futures-util v0.3.29
   Compiling pin-utils v0.1.0
   Compiling futures-io v0.3.29
   Compiling pkg-config v0.3.27
   Compiling memchr v2.6.4
   Compiling serde v1.0.192
   Compiling thiserror v1.0.50
   Compiling parking_lot_core v0.9.9
   Compiling async-trait v0.1.74
   Compiling either v1.9.0
   Compiling scopeguard v1.2.0
   Compiling xml-rs v0.8.19
   Compiling cfg-if v1.0.0
   Compiling smallvec v1.11.2
   Compiling log v0.4.20
   Compiling bytes v1.5.0
   Compiling itertools v0.10.5
   Compiling slab v0.4.9
   Compiling lock_api v0.4.11
   Compiling bitflags v2.4.1
   Compiling hashbrown v0.14.2
   Compiling once_cell v1.18.0
   Compiling uuid v1.5.0
   Compiling static_assertions v1.1.0
   Compiling libdbus-sys v0.2.5
   Compiling quote v1.0.33
error: failed to run custom build command for `libdbus-sys v0.2.5`

Caused by:
  process didn't exit successfully: `/target/release/build/libdbus-sys-a5bd944697d4bc4a/build-script-build` (exit status: 101)
  --- stdout
  cargo:rerun-if-changed=build.rs
  cargo:rerun-if-changed=build_vendored.rs
  cargo:rerun-if-env-changed=DBUS_1_NO_PKG_CONFIG
  cargo:rerun-if-env-changed=PKG_CONFIG_ALLOW_CROSS_aarch64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_ALLOW_CROSS_aarch64_unknown_linux_gnu
  cargo:rerun-if-env-changed=TARGET_PKG_CONFIG_ALLOW_CROSS
  cargo:rerun-if-env-changed=PKG_CONFIG_ALLOW_CROSS
  cargo:rerun-if-env-changed=PKG_CONFIG_aarch64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_aarch64_unknown_linux_gnu
  cargo:rerun-if-env-changed=TARGET_PKG_CONFIG
  cargo:rerun-if-env-changed=PKG_CONFIG
  cargo:rerun-if-env-changed=DBUS_1_STATIC
  cargo:rerun-if-env-changed=DBUS_1_DYNAMIC
  cargo:rerun-if-env-changed=PKG_CONFIG_ALL_STATIC
  cargo:rerun-if-env-changed=PKG_CONFIG_ALL_DYNAMIC
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH_aarch64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH_aarch64_unknown_linux_gnu
  cargo:rerun-if-env-changed=TARGET_PKG_CONFIG_PATH
  cargo:rerun-if-env-changed=PKG_CONFIG_PATH
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR_aarch64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR_aarch64_unknown_linux_gnu
  cargo:rerun-if-env-changed=TARGET_PKG_CONFIG_LIBDIR
  cargo:rerun-if-env-changed=PKG_CONFIG_LIBDIR
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_aarch64-unknown-linux-gnu
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_aarch64_unknown_linux_gnu
  cargo:rerun-if-env-changed=TARGET_PKG_CONFIG_SYSROOT_DIR
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR

  --- stderr
  pkg_config failed: `PKG_CONFIG_ALLOW_SYSTEM_CFLAGS="1" PKG_CONFIG_ALLOW_SYSTEM_LIBS="1" PKG_CONFIG_PATH="/usr/lib/aarch64-linux-gnu/pkgconfig/:" "pkg-config" "--libs" "--cflags" "dbus-1" "dbus-1 >= 1.6"` did not exit successfully: exit status: 1
  error: could not find system library 'dbus-1' required by the 'libdbus-sys' crate

  --- stderr
  Package dbus-1 was not found in the pkg-config search path.
  Perhaps you should add the directory containing `dbus-1.pc'
  to the PKG_CONFIG_PATH environment variable
  No package 'dbus-1' found
  Package dbus-1 was not found in the pkg-config search path.
  Perhaps you should add the directory containing `dbus-1.pc'
  to the PKG_CONFIG_PATH environment variable
  No package 'dbus-1' found

  One possible solution is to check whether packages
  'libdbus-1-dev' and 'pkg-config' are installed:
  On Ubuntu:
  sudo apt install libdbus-1-dev pkg-config
  On Fedora:
  sudo dnf install dbus-devel pkgconf-pkg-config

  thread 'main' panicked at /home/mamadou/.cargo/registry/src/index.crates.io-6f17d22bba15001f/libdbus-sys-0.2.5/build.rs:25:9:
  explicit panic
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
warning: build failed, waiting for other jobs to finish...
```
