### PR TITLE
Add service_uuid to the ValueNotification struct

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -84,6 +84,8 @@ impl AddressType {
 /// A notification sent from a peripheral due to a change in a value.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ValueNotification {
+    /// UUID of the service that fired the notification.
+    pub service_uuid: Uuid,
     /// UUID of the characteristic that fired the notification.
     pub uuid: Uuid,
     /// The new value of the characteristic.

--- a/src/bluez/peripheral.rs
+++ b/src/bluez/peripheral.rs
@@ -283,7 +283,11 @@ fn value_notification(
         } if id.service().device() == *device_id => {
             let services = services.lock().unwrap();
             let (service, characteristic) = find_characteristic_by_id(&services, id)?;
-            Some(ValueNotification { uuid: characteristic.uuid, service_uuid: service.info.uuid, value })
+            Some(ValueNotification {
+                uuid: characteristic.uuid,
+                service_uuid: service.info.uuid,
+                value,
+            })
         }
         _ => None,
     }

--- a/src/bluez/peripheral.rs
+++ b/src/bluez/peripheral.rs
@@ -282,8 +282,8 @@ fn value_notification(
             event: CharacteristicEvent::Value { value },
         } if id.service().device() == *device_id => {
             let services = services.lock().unwrap();
-            let uuid = find_characteristic_by_id(&services, id)?.uuid;
-            Some(ValueNotification { uuid, value })
+            let (service, characteristic) = find_characteristic_by_id(&services, id)?;
+            Some(ValueNotification { uuid: characteristic.uuid, service_uuid: service.info.uuid, value })
         }
         _ => None,
     }
@@ -292,11 +292,11 @@ fn value_notification(
 fn find_characteristic_by_id(
     services: &HashMap<Uuid, ServiceInternal>,
     characteristic_id: CharacteristicId,
-) -> Option<&CharacteristicInfo> {
+) -> Option<(&ServiceInternal, &CharacteristicInfo)> {
     for service in services.values() {
         for characteristic in service.characteristics.values() {
             if characteristic.info.id == characteristic_id {
-                return Some(&characteristic.info);
+                return Some((service, &characteristic.info));
             }
         }
     }

--- a/src/corebluetooth/internal.rs
+++ b/src/corebluetooth/internal.rs
@@ -737,7 +737,11 @@ impl CoreBluetoothInternal {
                             .set_reply(CoreBluetoothReply::ReadResult(data_clone));
                     } else if let Err(e) = peripheral
                         .event_sender
-                        .send(CBPeripheralEvent::Notification(service_uuid, characteristic_uuid, data))
+                        .send(CBPeripheralEvent::Notification(
+                            service_uuid,
+                            characteristic_uuid,
+                            data,
+                        ))
                         .await
                     {
                         error!("Error sending notification event: {}", e);

--- a/src/corebluetooth/internal.rs
+++ b/src/corebluetooth/internal.rs
@@ -155,7 +155,7 @@ pub enum CoreBluetoothReply {
 #[derive(Debug)]
 pub enum CBPeripheralEvent {
     Disconnected,
-    Notification(Uuid, Vec<u8>),
+    Notification(Uuid, Uuid, Vec<u8>),
     ManufacturerData(u16, Vec<u8>, i16),
     ServiceData(HashMap<Uuid, Vec<u8>>, i16),
     Services(Vec<Uuid>, i16),
@@ -737,7 +737,7 @@ impl CoreBluetoothInternal {
                             .set_reply(CoreBluetoothReply::ReadResult(data_clone));
                     } else if let Err(e) = peripheral
                         .event_sender
-                        .send(CBPeripheralEvent::Notification(characteristic_uuid, data))
+                        .send(CBPeripheralEvent::Notification(service_uuid, characteristic_uuid, data))
                         .await
                     {
                         error!("Error sending notification event: {}", e);

--- a/src/corebluetooth/peripheral.rs
+++ b/src/corebluetooth/peripheral.rs
@@ -120,8 +120,8 @@ impl Peripheral {
 
             loop {
                 match event_receiver.next().await {
-                    Some(CBPeripheralEvent::Notification(uuid, data)) => {
-                        let notification = ValueNotification { uuid, value: data };
+                    Some(CBPeripheralEvent::Notification(service_uuid, uuid, data)) => {
+                        let notification = ValueNotification { service_uuid, uuid, value: data };
 
                         // Note: we ignore send errors here which may happen while there are no
                         // receivers...

--- a/src/corebluetooth/peripheral.rs
+++ b/src/corebluetooth/peripheral.rs
@@ -121,7 +121,11 @@ impl Peripheral {
             loop {
                 match event_receiver.next().await {
                     Some(CBPeripheralEvent::Notification(service_uuid, uuid, data)) => {
-                        let notification = ValueNotification { service_uuid, uuid, value: data };
+                        let notification = ValueNotification {
+                            service_uuid,
+                            uuid,
+                            value: data,
+                        };
 
                         // Note: we ignore send errors here which may happen while there are no
                         // receivers...

--- a/src/winrtble/peripheral.rs
+++ b/src/winrtble/peripheral.rs
@@ -497,10 +497,11 @@ impl ApiPeripheral for Peripheral {
             .ok_or_else(|| Error::NotSupported("Characteristic not found for subscribe".into()))?;
         let notifications_sender = self.shared.notifications_channel.clone();
         let uuid = characteristic.uuid;
+        let service_uuid = ble_service.uuid;
         ble_characteristic
             .subscribe(Box::new(move |value| {
                 let notification = ValueNotification {
-                    service_uuid: ble_service.uuid,
+                    service_uuid,
                     uuid,
                     value,
                 };

--- a/src/winrtble/peripheral.rs
+++ b/src/winrtble/peripheral.rs
@@ -499,7 +499,11 @@ impl ApiPeripheral for Peripheral {
         let uuid = characteristic.uuid;
         ble_characteristic
             .subscribe(Box::new(move |value| {
-                let notification = ValueNotification { uuid, value };
+                let notification = ValueNotification {
+                    service_uuid: ble_service.uuid,
+                    uuid,
+                    value,
+                };
                 // Note: we ignore send errors here which may happen while there are no
                 // receivers...
                 let _ = notifications_sender.send(notification);


### PR DESCRIPTION
Introduced `service_uuid` to `ValueNotification` struct to enhance clarity. This addition allows users to identify the service associated with each notification.

Not sure where I can take from the `service_uuid` in `droidplug`.