### PR TITLE
Handle failure in Peripheral::Connect by returning an error

### DIFF
--- a/src/corebluetooth/central_delegate.rs
+++ b/src/corebluetooth/central_delegate.rs
@@ -91,6 +91,7 @@ pub enum CentralDelegateEvent {
     },
     ConnectionFailed {
         peripheral_uuid: Uuid,
+        error_description: Option<String>,
     },
     DisconnectedDevice {
         peripheral_uuid: Uuid,
@@ -176,9 +177,13 @@ impl Debug for CentralDelegateEvent {
                 .debug_struct("ConnectedDevice")
                 .field("peripheral_uuid", peripheral_uuid)
                 .finish(),
-            CentralDelegateEvent::ConnectionFailed { peripheral_uuid } => f
+            CentralDelegateEvent::ConnectionFailed {
+                peripheral_uuid,
+                error_description,
+            } => f
                 .debug_struct("ConnectionFailed")
                 .field("peripheral_uuid", peripheral_uuid)
+                .field("error_description", error_description)
                 .finish(),
             CentralDelegateEvent::DisconnectedDevice { peripheral_uuid } => f
                 .debug_struct("DisconnectedDevice")
@@ -486,13 +491,18 @@ pub mod CentralDelegate {
         _cmd: Sel,
         _central: id,
         peripheral: id,
-        _error: id,
+        error: id,
     ) {
         trace!("delegate_centralmanager_didfailtoconnectperipheral_error");
         let peripheral_uuid = nsuuid_to_uuid(cb::peer_identifier(peripheral));
+        let error_description_ns = ns::error_localizeddescription(error);
+        let error_description = nsstring_to_string(error_description_ns);
         send_delegate_event(
             delegate,
-            CentralDelegateEvent::ConnectionFailed { peripheral_uuid },
+            CentralDelegateEvent::ConnectionFailed {
+                peripheral_uuid,
+                error_description,
+            },
         );
     }
 

--- a/src/corebluetooth/framework.rs
+++ b/src/corebluetooth/framework.rs
@@ -94,6 +94,15 @@ pub mod ns {
             uuidstring
         }
     }
+
+    // NSError
+
+    pub fn error_localizeddescription(nserror: id) -> id /* NSString* */ {
+        unsafe {
+            let description: id = msg_send![nserror, localizedDescription];
+            description
+        }
+    }
 }
 
 pub mod cb {

--- a/src/corebluetooth/internal.rs
+++ b/src/corebluetooth/internal.rs
@@ -606,8 +606,13 @@ impl CoreBluetoothInternal {
         // itself when it receives all of its service/characteristic info.
     }
 
-    fn on_peripheral_connection_failed(&mut self, peripheral_uuid: Uuid) {
+    fn on_peripheral_connection_failed(
+        &mut self,
+        peripheral_uuid: Uuid,
+        error_description: Option<String>,
+    ) {
         trace!("Got connection fail event!");
+        let error = error_description.unwrap_or(String::from("Connection failed"));
         if self.peripherals.contains_key(&peripheral_uuid) {
             let peripheral = self
                 .peripherals
@@ -619,7 +624,7 @@ impl CoreBluetoothInternal {
                 .unwrap()
                 .lock()
                 .unwrap()
-                .set_reply(CoreBluetoothReply::Err(String::from("Connection failed")));
+                .set_reply(CoreBluetoothReply::Err(error));
         }
     }
 
@@ -1022,8 +1027,8 @@ impl CoreBluetoothInternal {
                     CentralDelegateEvent::ConnectedDevice{peripheral_uuid} => {
                             self.on_peripheral_connect(peripheral_uuid)
                     },
-                    CentralDelegateEvent::ConnectionFailed{peripheral_uuid} => {
-                        self.on_peripheral_connection_failed(peripheral_uuid)
+                    CentralDelegateEvent::ConnectionFailed{peripheral_uuid, error_description} => {
+                        self.on_peripheral_connection_failed(peripheral_uuid, error_description)
                     },
                     CentralDelegateEvent::DisconnectedDevice{peripheral_uuid} => {
                         self.on_peripheral_disconnect(peripheral_uuid).await

--- a/src/corebluetooth/peripheral.rs
+++ b/src/corebluetooth/peripheral.rs
@@ -248,7 +248,8 @@ impl api::Peripheral for Peripheral {
                 self.shared
                     .emit_event(CentralEvent::DeviceConnected(self.shared.uuid.into()));
             }
-            _ => panic!("Shouldn't get anything but connected!"),
+            CoreBluetoothReply::Err(msg) => return Err(Error::RuntimeError(msg)),
+            _ => panic!("Shouldn't get anything but connected or err!"),
         }
         trace!("Device connected!");
         Ok(())


### PR DESCRIPTION
I've been trying out btleplug on macOS for a toy project and I was hitting 
an error that resulted in a panic when trying to connect to a peripheral. 
Without this patch it looked like:

```
thread 'main' panicked at 'Shouldn't get anything but connected!', 
/Users/ted/.cargo/registry/src/index.crates.io-6f17d22bba15001f/btleplug-0.11.3/src/corebluetooth/peripheral.rs:251:18
```

With this patch I get the actual underlying error:

```
Error: Runtime Error: Peer removed pairing information
```

The meat of the patch is making `Peripheral::connect` handle 
`CoreBluetoothReply::Err`, since "failed to connect" seems like a 
situation that it ought to handle. The rest of the patch is just some 
niceties to grab the error message when the delegate's 
`centralManager:didFailToConnectPeripheral:error:` method gets called, and 
then propagate it through back to where we can actually use it. As part of 
that I added an `error_description` field to 
`CentralDelegateEvent::ConnectionFailed`, and `error_localizeddescription` 
to your Cocoa glue code.

This still didn't fix my problem but at least I get the error message and 
can figure out what I'm doing now!
