### PR TITLE
Drop async-trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ path = "src/lib.rs"
 serde = ["uuid/serde", "serde_cr", "serde_bytes"]
 
 [dependencies]
-async-trait = "0.1.74"
 log = "0.4.20"
 bitflags = "2.4.1"
 thiserror = "1.0.50"

--- a/src/bluez/adapter.rs
+++ b/src/bluez/adapter.rs
@@ -1,7 +1,6 @@
 use super::peripheral::{Peripheral, PeripheralId};
 use crate::api::{Central, CentralEvent, ScanFilter};
 use crate::{Error, Result};
-use async_trait::async_trait;
 use bluez_async::{
     AdapterId, BluetoothError, BluetoothEvent, BluetoothSession, DeviceEvent, DiscoveryFilter,
     Transport,
@@ -22,7 +21,6 @@ impl Adapter {
     }
 }
 
-#[async_trait]
 impl Central for Adapter {
     type Peripheral = Peripheral;
 

--- a/src/bluez/manager.rs
+++ b/src/bluez/manager.rs
@@ -1,6 +1,5 @@
 use super::adapter::Adapter;
 use crate::{api, Result};
-use async_trait::async_trait;
 use bluez_async::BluetoothSession;
 
 /// Implementation of [api::Manager](crate::api::Manager).
@@ -16,7 +15,6 @@ impl Manager {
     }
 }
 
-#[async_trait]
 impl api::Manager for Manager {
     type Adapter = Adapter;
 

--- a/src/bluez/peripheral.rs
+++ b/src/bluez/peripheral.rs
@@ -1,4 +1,3 @@
-use async_trait::async_trait;
 use bluez_async::{
     BluetoothEvent, BluetoothSession, CharacteristicEvent, CharacteristicFlags, CharacteristicId,
     CharacteristicInfo, DescriptorInfo, DeviceId, DeviceInfo, MacAddress, ServiceInfo,
@@ -128,7 +127,6 @@ impl Peripheral {
     }
 }
 
-#[async_trait]
 impl api::Peripheral for Peripheral {
     fn id(&self) -> PeripheralId {
         PeripheralId(self.device.to_owned())

--- a/src/corebluetooth/adapter.rs
+++ b/src/corebluetooth/adapter.rs
@@ -3,7 +3,6 @@ use super::peripheral::{Peripheral, PeripheralId};
 use crate::api::{Central, CentralEvent, ScanFilter};
 use crate::common::adapter_manager::AdapterManager;
 use crate::{Error, Result};
-use async_trait::async_trait;
 use futures::channel::mpsc::{self, Sender};
 use futures::sink::SinkExt;
 use futures::stream::{Stream, StreamExt};
@@ -79,7 +78,6 @@ impl Adapter {
     }
 }
 
-#[async_trait]
 impl Central for Adapter {
     type Peripheral = Peripheral;
 

--- a/src/corebluetooth/manager.rs
+++ b/src/corebluetooth/manager.rs
@@ -7,7 +7,6 @@
 
 use super::adapter::Adapter;
 use crate::{api, Result};
-use async_trait::async_trait;
 
 /// Implementation of [api::Manager](crate::api::Manager).
 #[derive(Clone, Debug)]
@@ -19,7 +18,6 @@ impl Manager {
     }
 }
 
-#[async_trait]
 impl api::Manager for Manager {
     type Adapter = Adapter;
 

--- a/src/corebluetooth/peripheral.rs
+++ b/src/corebluetooth/peripheral.rs
@@ -19,7 +19,6 @@ use crate::{
     common::{adapter_manager::AdapterManager, util::notifications_stream_from_broadcast_receiver},
     Error, Result,
 };
-use async_trait::async_trait;
 use futures::channel::mpsc::{Receiver, SendError, Sender};
 use futures::sink::SinkExt;
 use futures::stream::{Stream, StreamExt};
@@ -195,7 +194,6 @@ impl Debug for Peripheral {
     }
 }
 
-#[async_trait]
 impl api::Peripheral for Peripheral {
     fn id(&self) -> PeripheralId {
         PeripheralId(self.shared.uuid)

--- a/src/droidplug/adapter.rs
+++ b/src/droidplug/adapter.rs
@@ -10,7 +10,6 @@ use crate::{
     common::adapter_manager::AdapterManager,
     Error, Result,
 };
-use async_trait::async_trait;
 use futures::stream::Stream;
 use jni::{
     objects::{GlobalRef, JObject, JString},
@@ -123,7 +122,6 @@ impl Adapter {
     }
 }
 
-#[async_trait]
 impl Central for Adapter {
     type Peripheral = Peripheral;
 

--- a/src/droidplug/manager.rs
+++ b/src/droidplug/manager.rs
@@ -1,6 +1,5 @@
 use super::adapter::Adapter;
 use crate::{api, Result};
-use async_trait::async_trait;
 
 #[derive(Clone, Debug)]
 pub struct Manager;
@@ -11,7 +10,6 @@ impl Manager {
     }
 }
 
-#[async_trait]
 impl api::Manager for Manager {
     type Adapter = Adapter;
 

--- a/src/droidplug/peripheral.rs
+++ b/src/droidplug/peripheral.rs
@@ -5,7 +5,6 @@ use crate::{
     },
     Error, Result,
 };
-use async_trait::async_trait;
 use futures::stream::Stream;
 use jni::{
     descriptors,
@@ -206,7 +205,6 @@ impl Debug for Peripheral {
     }
 }
 
-#[async_trait]
 impl api::Peripheral for Peripheral {
     /// Returns the unique identifier of the peripheral.
     fn id(&self) -> PeripheralId {

--- a/src/winrtble/adapter.rs
+++ b/src/winrtble/adapter.rs
@@ -17,7 +17,6 @@ use crate::{
     common::adapter_manager::AdapterManager,
     Error, Result,
 };
-use async_trait::async_trait;
 use futures::stream::Stream;
 use std::convert::TryInto;
 use std::fmt::{self, Debug, Formatter};
@@ -47,7 +46,6 @@ impl Debug for Adapter {
     }
 }
 
-#[async_trait]
 impl Central for Adapter {
     type Peripheral = Peripheral;
 

--- a/src/winrtble/manager.rs
+++ b/src/winrtble/manager.rs
@@ -13,7 +13,6 @@
 
 use super::adapter::Adapter;
 use crate::{api, Result};
-use async_trait::async_trait;
 use windows::Devices::Radios::{Radio, RadioKind};
 
 /// Implementation of [api::Manager](crate::api::Manager).
@@ -26,7 +25,6 @@ impl Manager {
     }
 }
 
-#[async_trait]
 impl api::Manager for Manager {
     type Adapter = Adapter;
 

--- a/src/winrtble/peripheral.rs
+++ b/src/winrtble/peripheral.rs
@@ -24,7 +24,6 @@ use crate::{
     common::{adapter_manager::AdapterManager, util::notifications_stream_from_broadcast_receiver},
     Error, Result,
 };
-use async_trait::async_trait;
 use dashmap::DashMap;
 use futures::stream::Stream;
 use log::{error, trace};
@@ -328,7 +327,6 @@ impl Debug for Peripheral {
     }
 }
 
-#[async_trait]
 impl ApiPeripheral for Peripheral {
     fn id(&self) -> PeripheralId {
         PeripheralId(self.shared.address)


### PR DESCRIPTION
This is a preview and in anticipation of Rust 1.75. But it works well with current nightly either. Note that the public trait API requires the desugared form in order to specify the `Send` bound on the returned future.