### PR TITLE
fix: winrt: Return error when discovering services fails

### DIFF
--- a/src/winrtble/peripheral.rs
+++ b/src/winrtble/peripheral.rs
@@ -454,6 +454,7 @@ impl ApiPeripheral for Peripheral {
                         }
                         Err(e) => {
                             error!("get_characteristics_async {:?}", e);
+                            return Err(e);
                         }
                     }
                 }


### PR DESCRIPTION
Prior to this commit, the `discover_services` method would return `Ok(())` even if the underlying calls had failed.

This was causing a deadlock on my system when I tried to reconnect to a device that had just been disconnected.