### PR TITLE
Ignore failed descriptor reads on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.11.5 (2024-01-10)
+
+## Bugfixes
+
+- Fix issue with Windows failing to read characteristic descriptors
+
 # 0.11.4 (2024-01-01)
 
 ## Bugfixes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "btleplug"
-version = "0.11.4"
+version = "0.11.5"
 authors = ["Nonpolynomial, LLC <kyle@nonpolynomial.com>"]
 license = "MIT/Apache-2.0/BSD-3-Clause"
 repository = "https://github.com/deviceplug/btleplug"

--- a/src/winrtble/peripheral.rs
+++ b/src/winrtble/peripheral.rs
@@ -27,7 +27,7 @@ use crate::{
 use async_trait::async_trait;
 use dashmap::DashMap;
 use futures::stream::Stream;
-use log::{error, trace};
+use log::{trace, warn};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "serde")]
@@ -449,8 +449,7 @@ impl ApiPeripheral for Peripheral {
                             );
                         }
                         Err(e) => {
-                            error!("get_characteristics_async {:?}", e);
-                            return Err(e);
+                            warn!("get_characteristics_async {:?}", e);
                         }
                     }
                 }

--- a/src/winrtble/peripheral.rs
+++ b/src/winrtble/peripheral.rs
@@ -415,29 +415,23 @@ impl ApiPeripheral for Peripheral {
                         Ok(characteristics) => {
                             let characteristics =
                                 characteristics.into_iter().map(|characteristic| async {
-                                    match BLEDevice::get_characteristic_descriptors(&characteristic)
-                                        .await
-                                    {
-                                        Ok(descriptors) => {
-                                            let descriptors: HashMap<Uuid, BLEDescriptor> =
-                                                descriptors
-                                                    .into_iter()
-                                                    .map(|descriptor| {
-                                                        let descriptor =
-                                                            BLEDescriptor::new(descriptor);
-                                                        (descriptor.uuid(), descriptor)
-                                                    })
-                                                    .collect();
-                                            Ok((characteristic, descriptors))
-                                        }
-                                        Err(e) => {
-                                            error!("get_characteristic_descriptors_async {:?}", e);
-                                            Err(e)
-                                        }
-                                    }
+                                    let c = characteristic.clone();
+                                    (
+                                        characteristic,
+                                        BLEDevice::get_characteristic_descriptors(&c)
+                                            .await
+                                            .unwrap_or(Vec::new())
+                                            .into_iter()
+                                            .map(|descriptor| {
+                                                let descriptor = BLEDescriptor::new(descriptor);
+                                                (descriptor.uuid(), descriptor)
+                                            })
+                                            .collect(),
+                                    )
                                 });
-                            let characteristics = futures::future::try_join_all(characteristics)
-                                .await?
+
+                            let characteristics = futures::future::join_all(characteristics)
+                                .await
                                 .into_iter()
                                 .map(|(characteristic, descriptors)| {
                                     let characteristic =


### PR DESCRIPTION
This brings the Windows implementation in line with Linux

Fixes #361