### PR TITLE
fix: Duplicate Characteristic UUID overwrite each other

### DIFF
--- a/src/corebluetooth/internal.rs
+++ b/src/corebluetooth/internal.rs
@@ -217,15 +217,20 @@ impl PeripheralInternal {
         service_uuid: Uuid,
         characteristics: HashMap<Uuid, Retained<CBCharacteristic>>,
     ) {
-        let characteristics = characteristics
-            .into_iter()
-            .map(|(characteristic_uuid, characteristic)| {
-                (
-                    characteristic_uuid,
-                    CharacteristicInternal::new(characteristic),
-                )
-            })
-            .collect();
+        let characteristics = characteristics.into_iter().fold(
+            // Only consider the first characteristic of each UUID
+            // This "should" be unique, but of course it's not enforced
+            HashMap::<Uuid, CharacteristicInternal>::new(),
+            |mut map, (characteristic_uuid, characteristic)| {
+                if !map.contains_key(&characteristic_uuid) {
+                    map.insert(
+                        characteristic_uuid,
+                        CharacteristicInternal::new(characteristic),
+                    );
+                }
+                map
+            },
+        );
         let service = self
             .services
             .get_mut(&service_uuid)


### PR DESCRIPTION
If a device (like the LOOB) declares multiple characteristics on a service with the same UUID, the last declared characteristic is used not the first (which is what the LOOB requires us to control).

Ideally we'd have access to them all, but since we can't tell them apart at the higher levels first wins seems better than last wins.

This has been tested on Windows, macOS, Android and Linux