### PR TITLE
Feat: CentralState

### DIFF
--- a/examples/event_driven_discovery.rs
+++ b/examples/event_driven_discovery.rs
@@ -23,6 +23,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // connect to the adapter
     let central = get_central(&manager).await;
 
+    let central_state = central.adapter_state().await.unwrap();
+    println!("CentralState: {:?}", central_state);
+
     // Each adapter has an event stream, we fetch via events(),
     // simplifying the type, this will return what is essentially a
     // Future<Result<Stream<Item=CentralEvent>>>.
@@ -44,6 +47,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
                     .map(|local_name| format!("Name: {local_name}"))
                     .unwrap_or_default();
                 println!("DeviceDiscovered: {:?} {}", id, name);
+            }
+            CentralEvent::StateUpdate(state) => {
+                println!("AdapterStatusUpdate {:?}", state);
             }
             CentralEvent::DeviceConnected(id) => {
                 println!("DeviceConnected: {:?}", id);

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -300,6 +300,19 @@ pub trait Peripheral: Send + Sync + Clone + Debug {
     derive(Serialize, Deserialize),
     serde(crate = "serde_cr")
 )]
+/// The state of the Central
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum CentralState {
+    Unknown = 0,
+    PoweredOn = 1,
+    PoweredOff = 2,
+}
+
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_cr")
+)]
 #[derive(Debug, Clone)]
 pub enum CentralEvent {
     DeviceDiscovered(PeripheralId),
@@ -321,6 +334,7 @@ pub enum CentralEvent {
         id: PeripheralId,
         services: Vec<Uuid>,
     },
+    StateUpdate(CentralState),
 }
 
 /// Central is the "client" of BLE. It's able to scan for and establish connections to peripherals.
@@ -360,6 +374,9 @@ pub trait Central: Send + Sync + Clone {
     /// The details of this are platform-specific andyou should not attempt to parse it, but it may
     /// be useful for debug logs.
     async fn adapter_info(&self) -> Result<String>;
+
+    /// Get information about the Bluetooth adapter state.
+    async fn adapter_state(&self) -> Result<CentralState>;
 }
 
 /// The Manager is the entry point to the library, providing access to all the Bluetooth adapters on

--- a/src/bluez/adapter.rs
+++ b/src/bluez/adapter.rs
@@ -1,5 +1,5 @@
 use super::peripheral::{Peripheral, PeripheralId};
-use crate::api::{Central, CentralEvent, ScanFilter};
+use crate::api::{Central, CentralEvent, CentralState, ScanFilter};
 use crate::{Error, Result};
 use async_trait::async_trait;
 use bluez_async::{
@@ -104,6 +104,10 @@ impl Central for Adapter {
     async fn adapter_info(&self) -> Result<String> {
         let adapter_info = self.session.get_adapter_info(&self.adapter).await?;
         Ok(format!("{} ({})", adapter_info.id, adapter_info.modalias))
+    }
+
+    async fn adapter_state(&self) -> Result<CentralState> {
+        Ok(CentralState::Unknown)
     }
 }
 

--- a/src/corebluetooth/adapter.rs
+++ b/src/corebluetooth/adapter.rs
@@ -29,7 +29,7 @@ impl Adapter {
         debug!("Waiting on adapter connect");
         if !matches!(
             receiver.next().await,
-            Some(CoreBluetoothEvent::AdapterConnected)
+            Some(CoreBluetoothEvent::DidUpdateState{state:_})
         ) {
             return Err(Error::Other(
                 "Adapter failed to connect.".to_string().into(),

--- a/src/corebluetooth/adapter.rs
+++ b/src/corebluetooth/adapter.rs
@@ -1,6 +1,6 @@
 use super::internal::{run_corebluetooth_thread, CoreBluetoothEvent, CoreBluetoothMessage};
 use super::peripheral::{Peripheral, PeripheralId};
-use crate::api::{Central, CentralEvent, ScanFilter};
+use crate::api::{Central, CentralEvent, CentralState, ScanFilter};
 use crate::common::adapter_manager::AdapterManager;
 use crate::{Error, Result};
 use async_trait::async_trait;
@@ -120,5 +120,9 @@ impl Central for Adapter {
     async fn adapter_info(&self) -> Result<String> {
         // TODO: Get information about the adapter.
         Ok("CoreBluetooth".to_string())
+    }
+
+    async fn adapter_state(&self) -> Result<CentralState> {
+        Ok(CentralState::Unknown)
     }
 }

--- a/src/droidplug/adapter.rs
+++ b/src/droidplug/adapter.rs
@@ -6,7 +6,7 @@ use super::{
     peripheral::{Peripheral, PeripheralId},
 };
 use crate::{
-    api::{BDAddr, Central, CentralEvent, PeripheralProperties, ScanFilter},
+    api::{BDAddr, Central, CentralEvent, CentralState, PeripheralProperties, ScanFilter},
     common::adapter_manager::AdapterManager,
     Error, Result,
 };
@@ -166,6 +166,10 @@ impl Central for Adapter {
 
     async fn add_peripheral(&self, address: &PeripheralId) -> Result<Peripheral> {
         self.add(address.0)
+    }
+
+    async fn adapter_state(&self) -> Result<CentralState> {
+        Ok(CentralState::Unknown)
     }
 }
 

--- a/src/winrtble/adapter.rs
+++ b/src/winrtble/adapter.rs
@@ -13,7 +13,7 @@
 
 use super::{ble::watcher::BLEWatcher, peripheral::Peripheral, peripheral::PeripheralId};
 use crate::{
-    api::{BDAddr, Central, CentralEvent, ScanFilter},
+    api::{BDAddr, Central, CentralEvent, CentralState, ScanFilter},
     common::adapter_manager::AdapterManager,
     Error, Result,
 };
@@ -99,5 +99,9 @@ impl Central for Adapter {
     async fn adapter_info(&self) -> Result<String> {
         // TODO: Get information about the adapter.
         Ok("WinRT".to_string())
+    }
+
+    async fn adapter_state(&self) -> Result<CentralState> {
+        Ok(CentralState::Unknown)
     }
 }

--- a/src/winrtble/adapter.rs
+++ b/src/winrtble/adapter.rs
@@ -23,19 +23,50 @@ use std::convert::TryInto;
 use std::fmt::{self, Debug, Formatter};
 use std::pin::Pin;
 use std::sync::{Arc, Mutex};
+use windows::{
+    Devices::Radios::{Radio, RadioState},
+    Foundation::TypedEventHandler,
+};
 
 /// Implementation of [api::Central](crate::api::Central).
 #[derive(Clone)]
 pub struct Adapter {
     watcher: Arc<Mutex<BLEWatcher>>,
     manager: Arc<AdapterManager<Peripheral>>,
+    radio: Radio,
+}
+
+// https://github.com/microsoft/windows-rs/blob/master/crates/libs/windows/src/Windows/Devices/Radios/mod.rs
+fn get_central_state(radio: &Radio) -> CentralState {
+    let state = radio.State().unwrap_or(RadioState::Unknown);
+    match state {
+        RadioState::On => CentralState::PoweredOn,
+        RadioState::Off => CentralState::PoweredOff,
+        _ => CentralState::Unknown,
+    }
 }
 
 impl Adapter {
-    pub(crate) fn new() -> Self {
+    pub(crate) fn new(radio: Radio) -> Self {
         let watcher = Arc::new(Mutex::new(BLEWatcher::new()));
         let manager = Arc::new(AdapterManager::default());
-        Adapter { watcher, manager }
+
+        let radio_clone = radio.clone();
+        let manager_clone = manager.clone();
+        let handler = TypedEventHandler::new(move |_sender, _args| {
+            let state = get_central_state(&radio_clone);
+            manager_clone.emit(CentralEvent::StateUpdate(state.into()));
+            Ok(())
+        });
+        if let Err(err) = radio.StateChanged(&handler) {
+            eprintln!("radio.StateChanged error: {}", err);
+        }
+
+        Adapter {
+            watcher,
+            manager,
+            radio,
+        }
     }
 }
 
@@ -102,6 +133,6 @@ impl Central for Adapter {
     }
 
     async fn adapter_state(&self) -> Result<CentralState> {
-        Ok(CentralState::Unknown)
+        Ok(get_central_state(&self.radio))
     }
 }

--- a/src/winrtble/manager.rs
+++ b/src/winrtble/manager.rs
@@ -35,7 +35,7 @@ impl api::Manager for Manager {
         Ok(radios
             .into_iter()
             .filter(|radio| radio.Kind() == Ok(RadioKind::Bluetooth))
-            .map(|_| Adapter::new())
+            .map(|radio| Adapter::new(radio))
             .collect())
     }
 }


### PR DESCRIPTION
Hi,

I'm working on bluetooth integration for [trezor-suite](https://github.com/trezor/trezor-suite) app and i would like to use `btleplug` as a bridge between the electron app and bluetooth device.
To make it work i would like to contribute and address some missing features and issues

### CentralState

Implementation of https://github.com/deviceplug/btleplug/issues/280 for macos, windows and linux.

I wasn't sure should i extend existing `adapter_info` method or just add new `adapter_state`, just for clarity i've added new function. I'm leaving this decision to you.
Also i'm not sure about the naming `adapter_state() -> CentralState` i didn't want to mess up current naming convention.
Feel free to nitpick anything.

Tested on Windows 10, macOS sonoma, linux nixOS

### Commits

- c244d4170b93fa904bf67d0848926058284cdd30 add `CBManagerState` getter https://developer.apple.com/documentation/corebluetooth/cbmanagerstate in `corebluetooth` delegate. The state is emitted in `CentralDelegateEvent::DidUpdateState` event.

- 6cdb1707a39554cba32811326254cd363b38cee3 add `api::Adapter.adapter_state` function and `CentralEvent::StateUpdate` event, by default all targets returns `CentralState::Unknown`

- e13a5e1b8f7a5f6501912fa3016341662684131d implementation for corebluetooth using delegate `centralmanager_state` getter

- 08ef9a1770f7446c7d3505f029b827a7233b30a3 implementation for bluez using `BluetoothEvent::Adapter` event

- c608e55143613d6f88379416b80cdff5c565c7b3 implementation for winrtble using `Radio.State()` https://github.com/microsoft/windows-rs/blob/master/crates/libs/windows/src/Windows/Devices/Radios/mod.rs - ~~there might be some side effects, not sure why sometimes i'm receiving same event twice, but i don't mind that~~