### PR TITLE
Make Shared.uuid Public

### DIFF
--- a/src/corebluetooth/peripheral.rs
+++ b/src/corebluetooth/peripheral.rs
@@ -56,13 +56,13 @@ impl Display for PeripheralId {
 /// Implementation of [api::Peripheral](crate::api::Peripheral).
 #[derive(Clone)]
 pub struct Peripheral {
-    shared: Arc<Shared>,
+    pub shared: Arc<Shared>,
 }
 
-struct Shared {
+pub struct Shared {
     notifications_channel: broadcast::Sender<ValueNotification>,
     manager: Weak<AdapterManager<Peripheral>>,
-    uuid: Uuid,
+    pub uuid: Uuid,
     services: Mutex<BTreeSet<Service>>,
     properties: Mutex<PeripheralProperties>,
     message_sender: Sender<CoreBluetoothMessage>,


### PR DESCRIPTION
As discussed in [!368](https://github.com/deviceplug/btleplug/issues/368):
> Given the lack of a consistent method to retrieve the actual MAC address, is it still possible to access the uuid as in previous versions?

I believe this is the `uuid` of interest - but it's private. Unless there's a compelling reason not to have it public, this is a PR to change that.