### PR TITLE
Add clear_peripherals method to adapter

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -355,6 +355,9 @@ pub trait Central: Send + Sync + Clone {
     /// Add a [`Peripheral`] from a MAC address without a scan result. Not supported on all Bluetooth systems.
     async fn add_peripheral(&self, address: &PeripheralId) -> Result<Self::Peripheral>;
 
+    /// Clear the list of [`Peripheral`]s that have been discovered so far.
+    async fn clear_peripherals(&self) -> Result<()>;
+
     /// Get information about the Bluetooth adapter being used, such as the model or type.
     ///
     /// The details of this are platform-specific andyou should not attempt to parse it, but it may

--- a/src/bluez/adapter.rs
+++ b/src/bluez/adapter.rs
@@ -101,6 +101,12 @@ impl Central for Adapter {
         ))
     }
 
+    async fn clear_peripherals(&self) -> Result<()> {
+        Err(Error::NotSupported(
+            "Can't clear peripheral list on this platform".to_string(),
+        ))
+    }
+
     async fn adapter_info(&self) -> Result<String> {
         let adapter_info = self.session.get_adapter_info(&self.adapter).await?;
         Ok(format!("{} ({})", adapter_info.id, adapter_info.modalias))

--- a/src/common/adapter_manager.rs
+++ b/src/common/adapter_manager.rs
@@ -66,6 +66,10 @@ where
         self.peripherals.insert(peripheral.id(), peripheral);
     }
 
+    pub fn clear_peripherals(&self) {
+        self.peripherals.clear();
+    }
+
     pub fn peripherals(&self) -> Vec<PeripheralType> {
         self.peripherals
             .iter()

--- a/src/corebluetooth/adapter.rs
+++ b/src/corebluetooth/adapter.rs
@@ -117,6 +117,11 @@ impl Central for Adapter {
         ))
     }
 
+    async fn clear_peripherals(&self) -> Result<()> {
+        self.manager.clear_peripherals();
+        Ok(())
+    }
+
     async fn adapter_info(&self) -> Result<String> {
         // TODO: Get information about the adapter.
         Ok("CoreBluetooth".to_string())

--- a/src/droidplug/adapter.rs
+++ b/src/droidplug/adapter.rs
@@ -167,6 +167,11 @@ impl Central for Adapter {
     async fn add_peripheral(&self, address: &PeripheralId) -> Result<Peripheral> {
         self.add(address.0)
     }
+
+    async fn clear_peripherals(&self) -> Result<()> {
+        self.manager.clear_peripherals();
+        Ok(())
+    }
 }
 
 pub(crate) fn adapter_report_scan_result_internal(

--- a/src/winrtble/adapter.rs
+++ b/src/winrtble/adapter.rs
@@ -96,6 +96,11 @@ impl Central for Adapter {
         ))
     }
 
+    async fn clear_peripherals(&self) -> Result<()> {
+        self.manager.clear_peripherals();
+        Ok(())
+    }
+
     async fn adapter_info(&self) -> Result<String> {
         // TODO: Get information about the adapter.
         Ok("WinRT".to_string())


### PR DESCRIPTION
Add clear_peripherals method to adapter, so that the peripheral list can be cleared after being used.
Without this, the list would keep growing until the whole adapter object is dropped.

The method returns a result so that later if a platform/functionality needs to be fallible the API won't need to be changed.

AFAIK, Linux doesn't support this as the peripheral list comes from bluez directly.

Solves https://github.com/deviceplug/btleplug/issues/206