### PR TITLE
Use correct size for hci_filter type

### DIFF
--- a/src/bluez/adapter/mod.rs
+++ b/src/bluez/adapter/mod.rs
@@ -245,7 +245,7 @@ impl ConnectedAdapter {
     }
 
     fn set_socket_filter(&self) -> Result<()> {
-        let mut filter = BytesMut::with_capacity(14);
+        let mut filter = BytesMut::with_capacity(16);
         let type_mask =
             (1 << HCI_COMMAND_PKT) | (1 << HCI_EVENT_PKT) as u8 | (1 << HCI_ACLDATA_PKT) as u8;
         let event_mask1 = (1 << EVT_DISCONN_COMPLETE)
@@ -254,11 +254,13 @@ impl ConnectedAdapter {
             | (1 << EVT_CMD_STATUS);
         let event_mask2 = 1 << (EVT_LE_META_EVENT - 32);
         let opcode = 0;
+        let padding = 0;
 
         filter.put_u32_le(type_mask as u32);
         filter.put_u32_le(event_mask1 as u32);
         filter.put_u32_le(event_mask2 as u32);
         filter.put_u16_le(opcode);
+        filter.put_u16_le(padding);
 
         handle_error(unsafe {
             libc::setsockopt(


### PR DESCRIPTION
This is for tag 0.5.5, not the master branch, but github doesn't let me create a PR with the tag as a base. Anyway... My proposed fix for issue 383.

Use 16 bytes for the filter structure in set_socket_filter(), not 14.

struct hci_filter unfortunately is not a packed struct:

https://git.kernel.org/pub/scm/bluetooth/bluez.git/tree/lib/hci.h

Hence, it has two bytes of padding at the end for correct stride of the 32-bit members.

This used to not be a problem until Linux kernel commit b2186061d6043 (Bluetooth: hci_sock: Fix not validating setsockopt user input) changed the behaviour of HCI_FILTER sockopt; before, the kernel would have truncated the read size but now the data supplied has to be at least the struct size, or we'd get -EINVAL.