### PR TITLE
Update platform.rs to add FreeBSD support

### DIFF
--- a/src/platform.rs
+++ b/src/platform.rs
@@ -1,7 +1,7 @@
 //! The `platform` module contains the platform-specific implementations of the various [`api`]
 //! traits. Refer for the `api` module for how to use them.
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "freebsd"))]
 pub use crate::bluez::{
     adapter::Adapter, manager::Manager, peripheral::Peripheral, peripheral::PeripheralId,
 };


### PR DESCRIPTION
Adding FreeBSD support to platform.rs as it affects the build of a downstream project