### PR TITLE
fix(macos): Break the corebluetooth loop when manager turned off

### DIFF
--- a/src/corebluetooth/framework.rs
+++ b/src/corebluetooth/framework.rs
@@ -82,6 +82,26 @@ pub mod cb {
         }
     }
 
+    #[derive(Copy, Clone, Debug, Eq, PartialEq)]
+    #[repr(i64)]
+    #[allow(dead_code)]
+    pub enum CBManagerState {
+        Unknown = 0,
+        Resetting = 1,
+        Unsupported = 2,
+        Unauthorized = 3,
+        PoweredOff = 4,
+        PoweredOn = 5,
+    }
+
+    unsafe impl Encode for CBManagerState {
+        const ENCODING: Encoding = i64::ENCODING;
+    }
+
+    pub fn centeralmanger_state(cbcentralmanager: id) -> CBManagerState {
+        unsafe { msg_send![cbcentralmanager, state] }
+    }
+
     pub fn centralmanager_stopscan(cbcentralmanager: id) {
         unsafe { msg_send![cbcentralmanager, stopScan] }
     }
@@ -130,10 +150,11 @@ pub mod cb {
         unsafe { msg_send_id![cbperipheral, name] }
     }
 
+    #[allow(dead_code)]
     #[derive(Copy, Clone, Debug, Eq, PartialEq)]
     #[repr(i64)]
     pub enum CBPeripheralState {
-        Disonnected = 0,
+        Disconnected = 0,
         Connecting = 1,
         Connected = 2,
         Disconnecting = 3,


### PR DESCRIPTION
closes https://github.com/deviceplug/btleplug/issues/387

In Core Bluetooth when the device is locked or suspended and it is not applicable for background Bluetooth access the manager will create an event for state change and after will change the manager state to powerOff. Currently, it is not tracked at all which
leads to the forever stuck unresolved futures while the connection to peripheral is still held.

An additional problem I faced that there is no way to manually kill the
event loop of the corebluetooth from outside so the
`CoreBluetoothInternal::drop` is never called because it is always
living in the stalled thread.

In this change, I added an API to access the manager state and exited
the event loop when if the manager turned off.
