### PR TITLE
fix: make local_name in corebluetooth more descriptive

### DIFF
--- a/examples/event_driven_discovery.rs
+++ b/examples/event_driven_discovery.rs
@@ -1,7 +1,9 @@
 // See the "macOS permissions note" in README.md before running this on macOS
 // Big Sur or later.
 
-use btleplug::api::{bleuuid::BleUuid, Central, CentralEvent, Manager as _, ScanFilter};
+use btleplug::api::{
+    bleuuid::BleUuid, Central, CentralEvent, Manager as _, Peripheral, ScanFilter,
+};
 use btleplug::platform::{Adapter, Manager};
 use futures::stream::StreamExt;
 use std::error::Error;
@@ -35,7 +37,13 @@ async fn main() -> Result<(), Box<dyn Error>> {
     while let Some(event) = events.next().await {
         match event {
             CentralEvent::DeviceDiscovered(id) => {
-                println!("DeviceDiscovered: {:?}", id);
+                let peripheral = central.peripheral(&id).await?;
+                let properties = peripheral.properties().await?;
+                let name = properties
+                    .and_then(|p| p.local_name)
+                    .map(|local_name| format!("Name: {local_name}"))
+                    .unwrap_or_default();
+                println!("DeviceDiscovered: {:?} {}", id, name);
             }
             CentralEvent::DeviceConnected(id) => {
                 println!("DeviceConnected: {:?}", id);

--- a/src/corebluetooth/utils/mod.rs
+++ b/src/corebluetooth/utils/mod.rs
@@ -16,11 +16,20 @@
 // This file may not be copied, modified, or distributed except
 // according to those terms.
 
-use objc2_foundation::NSUUID;
+use std::ffi::CStr;
+
+use objc2_foundation::{NSString, NSUUID};
 use uuid::Uuid;
 
 pub mod core_bluetooth;
 
 pub fn nsuuid_to_uuid(uuid: &NSUUID) -> Uuid {
     uuid.UUIDString().to_string().parse().unwrap()
+}
+
+pub unsafe fn nsstring_to_string(nsstring: *const NSString) -> Option<String> {
+    nsstring
+        .as_ref()
+        .and_then(|ns| CStr::from_ptr(ns.UTF8String()).to_str().ok())
+        .map(String::from)
 }


### PR DESCRIPTION
# Issue description
Corebluetooth stack discovers my BTLE device with a very generic name while having a correct name on Windows and on Android.

# Change description
This PR implements the fix suggested in https://github.com/deviceplug/btleplug/issues/334 and extends the event_driven_discovery example to print peripheral names.

# Concerns
I'm not sure it's the best approach to merge `Advertisement Data[Local Name]` and peripheral names when they're both present, so I'm open for better ideas.