### PR TITLE
fix(macos): reading descriptor value

### DIFF
--- a/src/corebluetooth/central_delegate.rs
+++ b/src/corebluetooth/central_delegate.rs
@@ -599,7 +599,7 @@ declare_class!(
             }
         }
 
-        #[method(peripheral:didUpdateNotificationStateForCharacteristic:error:)]
+        #[method(peripheral:didWriteValueForCharacteristic:error:)]
         fn delegate_peripheral_didwritevalueforcharacteristic_error(
             &self,
             peripheral: &CBPeripheral,
@@ -622,7 +622,7 @@ declare_class!(
             }
         }
 
-        #[method(peripheral:didWriteValueForCharacteristic:error:)]
+        #[method(peripheral:didUpdateNotificationStateForCharacteristic:error:)]
         fn delegate_peripheral_didupdatenotificationstateforcharacteristic_error(
             &self,
             peripheral: &CBPeripheral,

--- a/src/corebluetooth/central_delegate.rs
+++ b/src/corebluetooth/central_delegate.rs
@@ -685,7 +685,7 @@ declare_class!(
                     service_uuid: cbuuid_to_uuid(unsafe { &service.UUID() }),
                     characteristic_uuid: cbuuid_to_uuid(unsafe { &characteristic.UUID() }),
                     descriptor_uuid: cbuuid_to_uuid(unsafe { &descriptor.UUID() }),
-                    data: get_characteristic_value(&characteristic),
+                    data: get_descriptor_value(&descriptor),
                 });
                 // Notify BluetoothGATTCharacteristic::read_value that read was successful.
             }
@@ -746,6 +746,21 @@ fn get_characteristic_value(characteristic: &CBCharacteristic) -> Vec<u8> {
     trace!("Getting data!");
     let v = unsafe { characteristic.value() }.map(|value| value.bytes().into());
     trace!("BluetoothGATTCharacteristic::get_value -> {:?}", v);
+    v.unwrap_or_default()
+}
+
+fn get_descriptor_value(descriptor: &CBDescriptor) -> Vec<u8> {
+    trace!("Getting data!");
+    let v = unsafe { descriptor.value() }.map(|value| unsafe {
+        match descriptor.UUID().UUIDString().to_string().as_str() {
+            "2901" => {
+                let d: Retained<NSString> = Retained::cast(value);
+                d.to_string().into_bytes()
+            }
+            _ => vec![],
+        }
+    });
+    trace!("BluetoothGATTDescriptor::get_value -> {:?}", v);
     v.unwrap_or_default()
 }
 

--- a/src/corebluetooth/internal.rs
+++ b/src/corebluetooth/internal.rs
@@ -1009,15 +1009,14 @@ impl CoreBluetoothInternal {
             if let Some(service) = peripheral.services.get_mut(&service_uuid) {
                 if let Some(characteristic) = service.characteristics.get_mut(&characteristic_uuid)
                 {
-                    if let Some(_descriptor) = characteristic.descriptors.get_mut(&descriptor_uuid)
-                    {
+                    if let Some(descriptor) = characteristic.descriptors.get_mut(&descriptor_uuid) {
                         trace!("Got read event!");
 
                         let mut data_clone = Vec::new();
                         for byte in data.iter() {
                             data_clone.push(*byte);
                         }
-                        let state = characteristic.read_future_state.pop_back().unwrap();
+                        let state = descriptor.read_future_state.pop_back().unwrap();
                         state
                             .lock()
                             .unwrap()


### PR DESCRIPTION
Reading out the value of the descriptors was not correctly implemented before. My solution needs to be extended with all the possible standards descriptor UUIDs but it provides a good starting point.

Also fixes a delegate bug (there were incorrect methods assigned to the functions)