### PR TITLE
Supports Windows 10 versions before 2004

### DIFF
--- a/src/winrtble/ble/watcher.rs
+++ b/src/winrtble/ble/watcher.rs
@@ -51,7 +51,7 @@ impl BLEWatcher {
         self.watcher
             .SetScanningMode(BluetoothLEScanningMode::Active)
             .unwrap();
-        self.watcher.SetAllowExtendedAdvertisements(true)?;
+        let _ = self.watcher.SetAllowExtendedAdvertisements(true);
         let handler: TypedEventHandler<
             BluetoothLEAdvertisementWatcher,
             BluetoothLEAdvertisementReceivedEventArgs,


### PR DESCRIPTION
Fixes for this issue: <https://github.com/deviceplug/btleplug/issues/364>.

Thanks to @ChristianPavilonis for providing the clue. He had forked this project and deleted the line that causes the problem.

This fix tries to keep the functionality as is, merely ignoring the returned error if `SetAllowExtendedAdvertisements()` isn't available.