### PR TITLE
Added support for Extended Advertisements for Android

### DIFF
--- a/src/droidplug/java/src/main/java/com/nonpolynomial/btleplug/android/impl/Adapter.java
+++ b/src/droidplug/java/src/main/java/com/nonpolynomial/btleplug/android/impl/Adapter.java
@@ -8,6 +8,7 @@ import android.bluetooth.le.ScanCallback;
 import android.bluetooth.le.ScanFilter.Builder;
 import android.bluetooth.le.ScanResult;
 import android.bluetooth.le.ScanSettings;
+import android.os.Build;
 import android.os.ParcelUuid;
 
 import java.util.ArrayList;
@@ -35,9 +36,17 @@ class Adapter {
                 filters.add(new Builder().setServiceUuid(ParcelUuid.fromString(uuid)).build());
             }
         }
-        ScanSettings settings = new ScanSettings.Builder()
-                .setCallbackType(ScanSettings.CALLBACK_TYPE_ALL_MATCHES)
-                .build();
+        ScanSettings settings;
+        if (Build.VERSION.SDK_INT >= 26) {
+            settings = new ScanSettings.Builder()
+                    .setCallbackType(ScanSettings.CALLBACK_TYPE_ALL_MATCHES)
+                    .setLegacy(false)
+                    .build();
+        } else {
+            settings = new ScanSettings.Builder()
+                    .setCallbackType(ScanSettings.CALLBACK_TYPE_ALL_MATCHES)
+                    .build();
+        }
         BluetoothLeScanner scanner = bluetoothAdapter.getBluetoothLeScanner();
         if (scanner == null) {
           throw new RuntimeException("No bluetooth scanner available for adapter");

--- a/src/droidplug/java/src/main/java/com/nonpolynomial/btleplug/android/impl/Peripheral.java
+++ b/src/droidplug/java/src/main/java/com/nonpolynomial/btleplug/android/impl/Peripheral.java
@@ -37,7 +37,7 @@ class Peripheral {
     private CommandCallback commandCallback;
 
     public Peripheral(Adapter adapter, String address) {
-        this.device = BluetoothAdapter.getAdapter().getRemoteDevice(address);
+        this.device = BluetoothAdapter.getDefaultAdapter().getRemoteDevice(address);
         this.adapter = adapter;
         this.callback = new Callback();
     }


### PR DESCRIPTION
This PR adds support for Extended Advertisements from Bluetooth 5.0 on Android.

When creating the `ScanSettings` object by default only Legacy Advertisements are reported to the ScanCallback. From API Level 26 (Oreo) the developer has the option to also include Extended Advertisements to the reported ScanResults.

Furthermore it is fixing a build issue in the Peripheral.java file where the wrong API call to `BluetoothAdapter` is getting called and I updated it here as well. If necessary I can also do this in a separate PR.