### PR TITLE
Add MTU support across all platforms

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ tokio-stream = { version = "0.1.16", features = ["sync"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 dbus = "0.9.7"
-bluez-async = "0.7.2"
+bluez-async = "0.8.0"
 
 [target.'cfg(target_os = "android")'.dependencies]
 jni = "0.19.0"

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -43,6 +43,9 @@ pub use self::bdaddr::{BDAddr, ParseBDAddrError};
 
 use crate::platform::PeripheralId;
 
+/// The default MTU size for a peripheral.
+pub const DEFAULT_MTU_SIZE: u16 = 23;
+
 #[cfg_attr(
     feature = "serde",
     derive(Serialize, Deserialize),

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -230,6 +230,9 @@ pub trait Peripheral: Send + Sync + Clone + Debug {
     /// Returns the MAC address of the peripheral.
     fn address(&self) -> BDAddr;
 
+    /// Returns the currently negotiated mtu size
+    fn mtu(&self) -> u16;
+
     /// Returns the set of properties associated with the peripheral. These may be updated over time
     /// as additional advertising reports are received.
     async fn properties(&self) -> Result<Option<PeripheralProperties>>;

--- a/src/bluez/peripheral.rs
+++ b/src/bluez/peripheral.rs
@@ -138,6 +138,17 @@ impl api::Peripheral for Peripheral {
         self.mac_address
     }
 
+    fn mtu(&self) -> u16 {
+        let services = self.services.lock().unwrap();
+        for (_, service) in services.iter() {
+            for (_, characteristic) in service.characteristics.iter() {
+                return characteristic.info.mtu.unwrap();
+            }
+        }
+        
+        api::DEFAULT_MTU_SIZE
+    }
+
     async fn properties(&self) -> Result<Option<PeripheralProperties>> {
         let device_info = self.device_info().await?;
         Ok(Some(PeripheralProperties {

--- a/src/winrtble/ble/device.rs
+++ b/src/winrtble/ble/device.rs
@@ -66,6 +66,7 @@ impl BLEDevice {
             .ConnectionStatusChanged(&connection_status_handler)
             .map_err(|_| Error::Other("Could not add connection status handler".into()))?;
 
+        max_pdu_size_changed(gatt_session.MaxPduSize().unwrap());
         let max_pdu_size_changed_handler =
             TypedEventHandler::new(move |sender: &Option<GattSession>, _| {
                 if let Some(sender) = sender {

--- a/src/winrtble/ble/device.rs
+++ b/src/winrtble/ble/device.rs
@@ -18,17 +18,20 @@ use windows::{
         BluetoothCacheMode, BluetoothConnectionStatus, BluetoothLEDevice,
         GenericAttributeProfile::{
             GattCharacteristic, GattCommunicationStatus, GattDescriptor, GattDeviceService,
-            GattDeviceServicesResult,
+            GattDeviceServicesResult, GattSession,
         },
     },
     Foundation::{EventRegistrationToken, TypedEventHandler},
 };
 
 pub type ConnectedEventHandler = Box<dyn Fn(bool) + Send>;
+pub type MaxPduSizeChangedEventHandler = Box<dyn Fn(u16) + Send>;
 
 pub struct BLEDevice {
     device: BluetoothLEDevice,
+    gatt_session: GattSession,
     connection_token: EventRegistrationToken,
+    pdu_change_token: EventRegistrationToken,
     services: Vec<GattDeviceService>,
 }
 
@@ -36,10 +39,16 @@ impl BLEDevice {
     pub async fn new(
         address: BDAddr,
         connection_status_changed: ConnectedEventHandler,
+        max_pdu_size_changed: MaxPduSizeChangedEventHandler,
     ) -> Result<Self> {
         let async_op = BluetoothLEDevice::FromBluetoothAddressAsync(address.into())
             .map_err(|_| Error::DeviceNotFound)?;
         let device = async_op.await.map_err(|_| Error::DeviceNotFound)?;
+
+        let async_op = GattSession::FromDeviceIdAsync(&device.BluetoothDeviceId()?)
+            .map_err(|_| Error::DeviceNotFound)?;
+        let gatt_session = async_op.await.map_err(|_| Error::DeviceNotFound)?;
+
         let connection_status_handler =
             TypedEventHandler::new(move |sender: &Option<BluetoothLEDevice>, _| {
                 if let Some(sender) = sender {
@@ -57,9 +66,22 @@ impl BLEDevice {
             .ConnectionStatusChanged(&connection_status_handler)
             .map_err(|_| Error::Other("Could not add connection status handler".into()))?;
 
+        let max_pdu_size_changed_handler =
+            TypedEventHandler::new(move |sender: &Option<GattSession>, _| {
+                if let Some(sender) = sender {
+                    max_pdu_size_changed(sender.MaxPduSize().unwrap());
+                }
+                Ok(())
+            });
+        let pdu_change_token = gatt_session
+            .MaxPduSizeChanged(&max_pdu_size_changed_handler)
+            .map_err(|_| Error::Other("Could not add max pdu size changed handler".into()))?;
+
         Ok(BLEDevice {
             device,
+            gatt_session,
             connection_token,
+            pdu_change_token,
             services: vec![],
         })
     }
@@ -167,6 +189,13 @@ impl BLEDevice {
 
 impl Drop for BLEDevice {
     fn drop(&mut self) {
+        let result = self
+            .gatt_session
+            .RemoveMaxPduSizeChanged(self.pdu_change_token);
+        if let Err(err) = result {
+            debug!("Drop: remove_max_pdu_size_changed {:?}", err);
+        }
+
         let result = self
             .device
             .RemoveConnectionStatusChanged(self.connection_token);

--- a/src/winrtble/peripheral.rs
+++ b/src/winrtble/peripheral.rs
@@ -46,9 +46,6 @@ use uuid::Uuid;
 use std::sync::Weak;
 use windows::Devices::Bluetooth::{Advertisement::*, BluetoothAddressType};
 
-/// The default MTU size for a peripheral.
-const DEFAULT_MTU_SIZE: u16 = 23;
-
 #[cfg_attr(
     feature = "serde",
     derive(Serialize, Deserialize),
@@ -97,7 +94,7 @@ impl Peripheral {
                 adapter,
                 device: tokio::sync::Mutex::new(None),
                 address,
-                mtu: AtomicU16::new(DEFAULT_MTU_SIZE),
+                mtu: AtomicU16::new(api::DEFAULT_MTU_SIZE),
                 connected: AtomicBool::new(false),
                 ble_services: DashMap::new(),
                 notifications_channel: broadcast_sender,

--- a/src/winrtble/peripheral.rs
+++ b/src/winrtble/peripheral.rs
@@ -46,6 +46,9 @@ use uuid::Uuid;
 use std::sync::Weak;
 use windows::Devices::Bluetooth::{Advertisement::*, BluetoothAddressType};
 
+/// The default MTU size for a peripheral.
+const DEFAULT_MTU_SIZE: u16 = 23;
+
 #[cfg_attr(
     feature = "serde",
     derive(Serialize, Deserialize),
@@ -94,7 +97,7 @@ impl Peripheral {
                 adapter,
                 device: tokio::sync::Mutex::new(None),
                 address,
-                mtu: AtomicU16::new(23),
+                mtu: AtomicU16::new(DEFAULT_MTU_SIZE),
                 connected: AtomicBool::new(false),
                 ble_services: DashMap::new(),
                 notifications_channel: broadcast_sender,

--- a/src/winrtble/peripheral.rs
+++ b/src/winrtble/peripheral.rs
@@ -37,7 +37,7 @@ use std::{
     convert::TryInto,
     fmt::{self, Debug, Display, Formatter},
     pin::Pin,
-    sync::atomic::{AtomicBool, Ordering},
+    sync::atomic::{AtomicBool, AtomicU16, Ordering},
     sync::{Arc, RwLock},
 };
 use tokio::sync::broadcast;
@@ -70,6 +70,7 @@ struct Shared {
     device: tokio::sync::Mutex<Option<BLEDevice>>,
     adapter: Weak<AdapterManager<Peripheral>>,
     address: BDAddr,
+    mtu: AtomicU16,
     connected: AtomicBool,
     ble_services: DashMap<Uuid, BLEService>,
     notifications_channel: broadcast::Sender<ValueNotification>,
@@ -93,6 +94,7 @@ impl Peripheral {
                 adapter,
                 device: tokio::sync::Mutex::new(None),
                 address,
+                mtu: AtomicU16::new(23),
                 connected: AtomicBool::new(false),
                 ble_services: DashMap::new(),
                 notifications_channel: broadcast_sender,
@@ -341,6 +343,11 @@ impl ApiPeripheral for Peripheral {
         self.shared.address
     }
 
+    /// Returns the currently negotiated mtu size
+    fn mtu(&self) -> u16 {
+        self.shared.mtu.load(Ordering::Relaxed)
+    }
+
     /// Returns the set of properties associated with the peripheral. These may be updated over time
     /// as additional advertising reports are received.
     async fn properties(&self) -> Result<Option<PeripheralProperties>> {
@@ -364,12 +371,12 @@ impl ApiPeripheral for Peripheral {
     /// Ok there has been successful connection. Note that peripherals allow only one connection at
     /// a time. Operations that attempt to communicate with a device will fail until it is connected.
     async fn connect(&self) -> Result<()> {
-        let shared_clone = Arc::downgrade(&self.shared);
         let adapter_clone = self.shared.adapter.clone();
         let address = self.shared.address;
-        let device = BLEDevice::new(
-            self.shared.address,
-            Box::new(move |is_connected| {
+
+        let connection_status_changed = Box::new({
+            let shared_clone = Arc::downgrade(&self.shared);
+            move |is_connected| {
                 if let Some(shared) = shared_clone.upgrade() {
                     shared.connected.store(is_connected, Ordering::Relaxed);
                 }
@@ -379,7 +386,22 @@ impl ApiPeripheral for Peripheral {
                         adapter.emit(CentralEvent::DeviceDisconnected(address.into()));
                     }
                 }
-            }),
+            }
+        });
+
+        let max_pdu_size_changed = Box::new({
+            let shared_clone = Arc::downgrade(&self.shared);
+            move |mtu| {
+                if let Some(shared) = shared_clone.upgrade() {
+                    shared.mtu.store(mtu, Ordering::Relaxed);
+                }
+            }
+        });
+
+        let device = BLEDevice::new(
+            self.shared.address,
+            connection_status_changed,
+            max_pdu_size_changed,
         )
         .await?;
 


### PR DESCRIPTION
This PR will include a method to retrieve the negotiated MTU size on each platform.

Info grabbed from: [deviceplug/btleplug#246](https://github.com/deviceplug/btleplug/issues/246)

Windows - [GattSession.MaxPduSize](https://learn.microsoft.com/en-us/uwp/api/windows.devices.bluetooth.genericattributeprofile.gattsession.maxpdusize?view=winrt-22621)
Negotiation happens on user's behalf, and a GattSession.MaxPduSizeChanged event is emitted when MTU is updated.

macOS / iOS - [CBPeripheral.maximumWriteValueLength](https://developer.apple.com/documentation/corebluetooth/cbperipheral/1620312-maximumwritevaluelength)
Negotiation happens on user's behalf, have used peripheral.maximumWriteValueLength(for: .withoutResponse) reliably in the past. .withResponse has some issues. [See here.](https://stackoverflow.com/a/68389331)

Linux
Instead of a dedicated MTU property, BlueZ has decided to adopt the newer Bluetooth 5.2 standard. Example here: [Link](https://github.com/OpenBluetoothToolbox/SimpleBLE/blob/614a5af35cdd22ba08318cb776795ecd2da8c389/simpleble/src/backends/linux/PeripheralBase.cpp#L57)

Android - [BluetoothGatt.requestMtu](https://developer.android.com/reference/android/bluetooth/BluetoothGatt#requestMtu(int))
The way I understand it and have used it in the past, you call requestMtu with the largest you can support (e.g. 512), and it will negotiate the min(host.maxMtu, periph.maxMtu) and call onMtuChanged with the new mtu size.

TODO:

- [x] Windows
- [x] Linux
- [ ] Android
- [ ] macOS/iOS