### PR TITLE
fix: `corebluetooth` fulfill characteristics futures on peripheral disconnection

### DIFF
--- a/src/corebluetooth/peripheral.rs
+++ b/src/corebluetooth/peripheral.rs
@@ -314,6 +314,7 @@ impl api::Peripheral for Peripheral {
             .await?;
         match fut.await {
             CoreBluetoothReply::Ok => {}
+            CoreBluetoothReply::Err(msg) => return Err(Error::RuntimeError(msg)),
             reply => panic!("Unexpected reply: {:?}", reply),
         }
         Ok(())
@@ -333,6 +334,7 @@ impl api::Peripheral for Peripheral {
             .await?;
         match fut.await {
             CoreBluetoothReply::ReadResult(chars) => Ok(chars),
+            CoreBluetoothReply::Err(msg) => return Err(Error::RuntimeError(msg)),
             _ => {
                 panic!("Shouldn't get anything but read result!");
             }
@@ -353,6 +355,7 @@ impl api::Peripheral for Peripheral {
             .await?;
         match fut.await {
             CoreBluetoothReply::Ok => trace!("subscribed!"),
+            CoreBluetoothReply::Err(msg) => return Err(Error::RuntimeError(msg)),
             _ => panic!("Didn't subscribe!"),
         }
         Ok(())
@@ -372,6 +375,7 @@ impl api::Peripheral for Peripheral {
             .await?;
         match fut.await {
             CoreBluetoothReply::Ok => {}
+            CoreBluetoothReply::Err(msg) => return Err(Error::RuntimeError(msg)),
             _ => panic!("Didn't unsubscribe!"),
         }
         Ok(())


### PR DESCRIPTION
Fixing `corebluetooth` pending subscription features.

Im trying to connect to a peripheral which requires number comparison pairing.
To enforce pairing process i need to call subscribe, read or write on protected characteristic, this will open native system window and display numbers to compare.

If everything goes well then i receive OK on the subscription.
However if i cancel the system number comparison or disconnect the device during that process i will get `DeviceDisconnected` event but those pending subscription requests are never resolved.

With this fix they should be fulfilled with "Device disconnected" error