### PR TITLE
Add support for building vendored dbus

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ path = "src/lib.rs"
 
 [features]
 serde = ["uuid/serde", "serde_cr", "serde_bytes"]
+dbus-vendored = ["dbus/vendored"]
 
 [dependencies]
 async-trait = "0.1.83"


### PR DESCRIPTION
Hi! This PR adds a new feature `dbus-vendored` which enables the build against vendored `dbus` as opposed to using system `.so`. I needed this to make the successful cross-platform build. It was previously discussed in the PR https://github.com/deviceplug/btleplug/pull/347 and it looks like the agreement was to add an optional feature for that.