### PR TITLE
Deserializing BDAddr from non-borrowed string without clone

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,3 +81,4 @@ rand = "0.8.5"
 pretty_env_logger = "0.5.0"
 tokio = { version = "1.40.0", features = ["macros", "rt", "rt-multi-thread"] }
 serde_json = "1.0.128"
+toml = "0.8.19"

--- a/src/api/bdaddr.rs
+++ b/src/api/bdaddr.rs
@@ -197,7 +197,6 @@ impl BDAddr {
 /// Different de-/serialization formats for [`BDAddr`].
 #[cfg(feature = "serde")]
 pub mod serde {
-    use std::borrow::Cow;
     use std::fmt::{self, Write as _};
 
     use serde::{


### PR DESCRIPTION
There was a problem with deserialization when using [toml](https://crates.io/crates/toml) crates, so I fixed it.

I often use toml files to configure my own software, but the following deserialization using toml was failing.

```rust
#[derive(Deserialize, PartialEq, Copy, Clone, Debug)]
struct Data {
    addr: BDAddr,
}

toml::from_str(r#"addr = "ff00ff00ff00""#) // error: A colon seperated Bluetooth address, like `00:11:22:33:44:55`
```
