### PR TITLE
Prepare for `objc2` frameworks v0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,8 @@ jni-utils = "0.1.1"
 
 [target.'cfg(target_vendor = "apple")'.dependencies]
 objc2 = "0.5.2"
-objc2-foundation = { version = "0.2.2", features = [
+objc2-foundation = { version = "0.2.2", default-features = false, features = [
+    "std",
     "block2",
     "NSArray",
     "NSData",
@@ -59,7 +60,8 @@ objc2-foundation = { version = "0.2.2", features = [
     "NSUUID",
     "NSValue",
 ] }
-objc2-core-bluetooth = { version = "0.2.2", features = [
+objc2-core-bluetooth = { version = "0.2.2", default-features = false, features = [
+    "std",
     "CBAdvertisementData",
     "CBAttribute",
     "CBCentralManager",


### PR DESCRIPTION
The next version of the `objc2` framework crates will have a bunch of default features enabled, see https://github.com/madsmtm/objc2/issues/627, so this PR pre-emptively disables them, so that your compile times down blow up once you upgrade to the next version (which is yet to be released, but will be soon).