### PR TITLE
Core Bluetooth: Add NSError to trace log message in disconnect message

### DIFF
--- a/src/corebluetooth/central_delegate.rs
+++ b/src/corebluetooth/central_delegate.rs
@@ -345,12 +345,12 @@ declare_class!(
             &self,
             _central: &CBCentralManager,
             peripheral: &CBPeripheral,
-            _error: Option<&NSError>,
+            error: Option<&NSError>,
         ) {
             trace!(
                 "delegate_centralmanager_diddisconnectperipheral_error {} (error={:?})",
                 peripheral_debug(peripheral),
-                _error
+                error
             );
             let peripheral_uuid = nsuuid_to_uuid(unsafe { &peripheral.identifier() });
             self.send_event(CentralDelegateEvent::DisconnectedDevice { peripheral_uuid });

--- a/src/corebluetooth/central_delegate.rs
+++ b/src/corebluetooth/central_delegate.rs
@@ -348,8 +348,9 @@ declare_class!(
             _error: Option<&NSError>,
         ) {
             trace!(
-                "delegate_centralmanager_diddisconnectperipheral_error {}",
-                peripheral_debug(peripheral)
+                "delegate_centralmanager_diddisconnectperipheral_error {} (error={:?})",
+                peripheral_debug(peripheral),
+                _error
             );
             let peripheral_uuid = nsuuid_to_uuid(unsafe { &peripheral.identifier() });
             self.send_event(CentralDelegateEvent::DisconnectedDevice { peripheral_uuid });


### PR DESCRIPTION
Thanks so much for this fantastic library!

This PR adds the debug description of the error parameter passed to `centralManager:didDisconnectPeripheral:error:` to the trace log. This additional detail can be useful when diagnosing unexpected peripheral disconnects.