### PR TITLE
impl From<BDAddr> for [u8; 6]

### DIFF
--- a/src/api/bdaddr.rs
+++ b/src/api/bdaddr.rs
@@ -76,6 +76,12 @@ impl From<[u8; 6]> for BDAddr {
     }
 }
 
+impl From<BDAddr> for [u8; 6] {
+    fn from(value: BDAddr) -> Self {
+        value.address
+    }
+}
+
 impl<'a> TryFrom<&'a [u8]> for BDAddr {
     type Error = ParseBDAddrError;
 


### PR DESCRIPTION
We can turn a `[u8; 6]` into a `BDAddr`, but the only way to go back is to go `BDAddr` -> `u64` -> `[u8; 8]` -> '[u8; 6]`.