### PR TITLE
Workaround for Cargo error: feature edition2024 is required; caused by bluez-async v0.8.1 migration to Rust 2024 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ tokio-stream = { version = "0.1.17", features = ["sync"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 dbus = "0.9.7"
-bluez-async = "0.8.0"
+bluez-async = "=0.8.0"
 
 [target.'cfg(target_os = "android")'.dependencies]
 jni = "0.19.0"


### PR DESCRIPTION
When building:

```
  Downloaded bluez-async v0.8.1
error: failed to parse manifest at `/home/mamadou/.cargo/registry/src/index.crates.io-6f17d22bba15001f/bluez-async-0.8.1/Cargo.toml`

Caused by:
  feature `edition2024` is required

  The package requires the Cargo feature called `edition2024`, but that feature is not stabilized in this version of Cargo (1.83.0 (5ffbef321 2024-10-29)).
  Consider trying a newer version of Cargo (this may require the nightly release).
  See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#edition-2024 for more information about the status of this feature.
```

Locking bluez-async to v0.8.0 works around the issue.