### PR TITLE
Fix: corebluetooth write without response

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ objc2-foundation = { version = "0.2.2", default-features = false, features = [
     "NSString",
     "NSUUID",
     "NSValue",
+    "NSProcessInfo",
 ] }
 objc2-core-bluetooth = { version = "0.2.2", default-features = false, features = [
     "std",

--- a/src/corebluetooth/internal.rs
+++ b/src/corebluetooth/internal.rs
@@ -38,6 +38,7 @@ use std::{
     fmt::{self, Debug, Formatter},
     ops::Deref,
     thread,
+    time::Duration,
 };
 use tokio::runtime;
 use uuid::Uuid;
@@ -887,6 +888,19 @@ impl CoreBluetoothInternal {
                 {
                     trace!("Writing value! With kind {:?}", kind);
                     unsafe {
+                        if kind == WriteType::WithoutResponse {
+                            // probably better idea would be to wait for the result of peripheral.peripheralIsReadyToSendWriteWithoutResponse
+                            let mut attempts = 0;
+                            while !peripheral.peripheral.canSendWriteWithoutResponse()
+                                && attempts < 100
+                            {
+                                attempts += 1;
+                                // min. connection interval time is 15ms. see the document:
+                                // https://developer.apple.com/library/archive/qa/qa1931/_index.html
+                                thread::sleep(Duration::from_millis(15));
+                            }
+                        }
+
                         peripheral.peripheral.writeValue_forCharacteristic_type(
                             &NSData::from_vec(data),
                             &characteristic.characteristic,

--- a/src/corebluetooth/internal.rs
+++ b/src/corebluetooth/internal.rs
@@ -31,7 +31,7 @@ use objc2_core_bluetooth::{
     CBCharacteristicProperties, CBCharacteristicWriteType, CBDescriptor, CBManager,
     CBManagerAuthorization, CBManagerState, CBPeripheral, CBPeripheralState, CBService, CBUUID,
 };
-use objc2_foundation::{NSArray, NSData, NSMutableDictionary, NSNumber};
+use objc2_foundation::{NSArray, NSData, NSMutableDictionary, NSNumber, NSProcessInfo};
 use std::{
     collections::{BTreeSet, HashMap, VecDeque},
     ffi::CString,
@@ -362,6 +362,12 @@ impl PeripheralInternal {
     }
 }
 
+/// Optional CoreBluetooth API capabilities that are available depending on the macOS version.
+struct CoreBluetoothFeatures {
+    /// `peripheral.canSendWriteWithoutResponse` property is available (since macOS 11.2.0)
+    can_send_write_without_response: bool,
+}
+
 // All of CoreBluetooth is basically async. It's all just waiting on delegate
 // events/callbacks. Therefore, we should be able to round up all of our wacky
 // ass mut *Object values, keep them in a single struct, in a single thread, and
@@ -376,6 +382,7 @@ struct CoreBluetoothInternal {
     // task::block this when sending even though it'll never actually block.
     event_sender: Sender<CoreBluetoothEvent>,
     message_receiver: Fuse<Receiver<CoreBluetoothMessage>>,
+    features: CoreBluetoothFeatures,
 }
 
 impl Debug for CoreBluetoothInternal {
@@ -474,6 +481,16 @@ pub enum CoreBluetoothEvent {
     },
 }
 
+fn get_features() -> CoreBluetoothFeatures {
+    let process_info = NSProcessInfo::processInfo();
+    let version = process_info.operatingSystemVersion();
+    let current = (version.majorVersion, version.minorVersion);
+
+    CoreBluetoothFeatures {
+        can_send_write_without_response: current >= (11, 2),
+    }
+}
+
 impl CoreBluetoothInternal {
     pub fn new(
         message_receiver: Receiver<CoreBluetoothMessage>,
@@ -499,6 +516,7 @@ impl CoreBluetoothInternal {
             event_sender,
             message_receiver: message_receiver.fuse(),
             delegate,
+            features: get_features(),
         }
     }
 
@@ -888,7 +906,9 @@ impl CoreBluetoothInternal {
                 {
                     trace!("Writing value! With kind {:?}", kind);
                     unsafe {
-                        if kind == WriteType::WithoutResponse {
+                        if kind == WriteType::WithoutResponse
+                            && self.features.can_send_write_without_response
+                        {
                             // probably better idea would be to wait for the result of peripheral.peripheralIsReadyToSendWriteWithoutResponse
                             let mut attempts = 0;
                             while !peripheral.peripheral.canSendWriteWithoutResponse()


### PR DESCRIPTION
Hi,

I've run into issue with `WriteType::WithoutResponse` on macos.
im trying to send ~2MB of data in shortest time possible however corebluetooth keeps loosing the packects shortly after the start.
```
When you use CBPeripheral.writeValue(_:for:type:) with .withoutResponse, CoreBluetooth:
- Queues the writes internally
- Starts transmitting them during connection intervals.
- Does not notify when it’s safe to send more.
- Silently drops writes if the queue is overwhelmed

```

while looking up for solutions in other bluetooth libs i came across [this technical document](https://developer.apple.com/library/archive/qa/qa1931/_index.html) and [this guide](https://punchthrough.com/core-bluetooth-guide/)

i belive the ultimate fix would be to use `peripheral.peripheralIsReadyToSendWriteWithoutResponse` as described in the guide but i dont see a easy way how to implement this method (missing CBPeripheralDelegate reference)

so i decided to use attempts loop and check every 15ms (`Interval Min` stated in the document) if it is safe to send another packet. the loop ends if true or after 100 retries (1500ms < `connSupervisionTimeout` stated in the document)

The only problem is that `canSendWriteWithoutResponse` was introduced in macos 11.0 (Big Sur) but it behaves unreliably  until 11.2 - returning false until the first write is performed. That is why i've added `can_send_without_response_supported` flag which is set from the `NSProcessInfo`.

if you dont care about older OS releases (Big Sur was released in november 2020) i can drop the the second commit 
 