### PR TITLE
add service uuids to notifications

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -86,6 +86,8 @@ impl AddressType {
 pub struct ValueNotification {
     /// UUID of the characteristic that fired the notification.
     pub uuid: Uuid,
+    /// UUID of the service that contains the characteristic.
+    pub service_uuid: Uuid,
     /// The new value of the characteristic.
     pub value: Vec<u8>,
 }

--- a/src/bluez/peripheral.rs
+++ b/src/bluez/peripheral.rs
@@ -298,11 +298,10 @@ fn value_notification(
             event: CharacteristicEvent::Value { value },
         } if id.service().device() == *device_id => {
             let services = services.lock().unwrap();
-            let info = find_characteristic_by_id(&services, id.clone())?;
-            let service = services.iter().find(|(_, s)| s.info.id == id.service())?.0;
+            let (charac, service) = find_characteristic_by_id(&services, id.clone())?;
             Some(ValueNotification {
-                uuid: info.uuid,
-                service_uuid: *service,
+                uuid: charac.uuid,
+                service_uuid: service.uuid,
                 value,
             })
         }
@@ -313,11 +312,11 @@ fn value_notification(
 fn find_characteristic_by_id(
     services: &HashMap<Uuid, ServiceInternal>,
     characteristic_id: CharacteristicId,
-) -> Option<&CharacteristicInfo> {
+) -> Option<(&CharacteristicInfo, &ServiceInfo)> {
     for service in services.values() {
         for characteristic in service.characteristics.values() {
             if characteristic.info.id == characteristic_id {
-                return Some(&characteristic.info);
+                return Some((&characteristic.info, &service.info));
             }
         }
     }

--- a/src/bluez/peripheral.rs
+++ b/src/bluez/peripheral.rs
@@ -298,8 +298,13 @@ fn value_notification(
             event: CharacteristicEvent::Value { value },
         } if id.service().device() == *device_id => {
             let services = services.lock().unwrap();
-            let uuid = find_characteristic_by_id(&services, id)?.uuid;
-            Some(ValueNotification { uuid, value })
+            let info = find_characteristic_by_id(&services, id.clone())?;
+            let service = services.iter().find(|(_, s)| s.info.id == id.service())?.0;
+            Some(ValueNotification {
+                uuid: info.uuid,
+                service_uuid: *service,
+                value,
+            })
         }
         _ => None,
     }

--- a/src/corebluetooth/internal.rs
+++ b/src/corebluetooth/internal.rs
@@ -157,7 +157,7 @@ pub enum CoreBluetoothReply {
 #[derive(Debug)]
 pub enum PeripheralEventInternal {
     Disconnected,
-    Notification(Uuid, Vec<u8>),
+    Notification(Uuid, Uuid, Vec<u8>),
     ManufacturerData(u16, Vec<u8>, i16),
     ServiceData(HashMap<Uuid, Vec<u8>>, i16),
     Services(Vec<Uuid>, i16),
@@ -818,6 +818,7 @@ impl CoreBluetoothInternal {
                         .event_sender
                         .send(PeripheralEventInternal::Notification(
                             characteristic_uuid,
+                            service_uuid,
                             data,
                         ))
                         .await

--- a/src/corebluetooth/peripheral.rs
+++ b/src/corebluetooth/peripheral.rs
@@ -118,8 +118,12 @@ impl Peripheral {
 
             loop {
                 match event_receiver.next().await {
-                    Some(PeripheralEventInternal::Notification(uuid, data)) => {
-                        let notification = ValueNotification { uuid, value: data };
+                    Some(PeripheralEventInternal::Notification(uuid, service_uuid, data)) => {
+                        let notification = ValueNotification {
+                            uuid,
+                            service_uuid,
+                            value: data,
+                        };
 
                         // Note: we ignore send errors here which may happen while there are no
                         // receivers...

--- a/src/droidplug/peripheral.rs
+++ b/src/droidplug/peripheral.rs
@@ -26,6 +26,7 @@ use std::{
     pin::Pin,
     sync::{Arc, Mutex},
 };
+use uuid::Uuid;
 
 use super::jni::{
     global_jvm,
@@ -367,7 +368,11 @@ impl api::Peripheral for Peripheral {
                     let characteristic = JBluetoothGattCharacteristic::from_env(&env, item)?;
                     let uuid = characteristic.get_uuid()?;
                     let value = characteristic.get_value()?;
-                    Ok(ValueNotification { uuid, value })
+                    Ok(ValueNotification {
+                        uuid,
+                        service_uuid: Uuid::default(),
+                        value,
+                    }) // TODO: get service UUID
                 }
                 Err(err) => Err(err),
             })

--- a/src/winrtble/peripheral.rs
+++ b/src/winrtble/peripheral.rs
@@ -509,9 +509,14 @@ impl ApiPeripheral for Peripheral {
             .ok_or_else(|| Error::NotSupported("Characteristic not found for subscribe".into()))?;
         let notifications_sender = self.shared.notifications_channel.clone();
         let uuid = characteristic.uuid;
+        let service_uuid = characteristic.service_uuid;
         ble_characteristic
             .subscribe(Box::new(move |value| {
-                let notification = ValueNotification { uuid, value };
+                let notification = ValueNotification {
+                    uuid,
+                    service_uuid,
+                    value,
+                };
                 // Note: we ignore send errors here which may happen while there are no
                 // receivers...
                 let _ = notifications_sender.send(notification);


### PR DESCRIPTION
I want to support multiple characteristics with the same UUID in different services in [tauri-plugin-blec](https://github.com/MnlPhlp/tauri-plugin-blec).
In order to support this for subscribes, the ValueNotification has to specifiy what service caused it.
I added the values for all the integrations except Android, because I don't really know how to work with the jni code.

I can look at the android version, but I would prefer if someone with more experience in this area could do that.

The problem is I need a new release of this library with the added fields in order to release my crate with the new dependency.
If i checked correctly, there is no way to publish to crates.io with my github fork as dependency
