### PR TITLE
fix: bluez device disconnection

### DIFF
--- a/src/bluez/adapter.rs
+++ b/src/bluez/adapter.rs
@@ -143,11 +143,10 @@ async fn central_event(
                 Some(CentralEvent::DeviceDiscovered(device.id.into()))
             }
             DeviceEvent::Connected { connected } => {
-                let device = session.get_device_info(&id).await.ok()?;
                 if connected {
-                    Some(CentralEvent::DeviceConnected(device.id.into()))
+                    Some(CentralEvent::DeviceConnected(id.into()))
                 } else {
-                    Some(CentralEvent::DeviceDisconnected(device.id.into()))
+                    Some(CentralEvent::DeviceDisconnected(id.into()))
                 }
             }
             DeviceEvent::Rssi { rssi: _ } => {


### PR DESCRIPTION
when device is upaired from the system settings while connected `CentralEvent::DeviceDisconnected` is never emitted.
it fails on line:
```
let device = session.get_device_info(&id).await.ok()?;
```
with error:

`Err(DbusError(D-Bus error: Method "GetAll" with signature "s" on interface "org.freedesktop.DBus.Properties" doesn't exist`


<img width="408" height="333" alt="Screenshot from 2025-10-22 13-58-48" src="https://github.com/user-attachments/assets/f9b4d6f5-1575-4716-aaa2-2e91daecc37e" />
