### PR TITLE
fix: corebluetooth peripheral name

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -179,8 +179,10 @@ pub struct PeripheralProperties {
     pub address: BDAddr,
     /// The type of address (either random or public)
     pub address_type: Option<AddressType>,
-    /// The local name. This is generally a human-readable string that identifies the type of device.
+    /// The GAP local name. This is generally a human-readable string that identifies the type of device.
     pub local_name: Option<String>,
+    /// The advertisement name. May be different than local_name.
+    pub advertisement_name: Option<String>,
     /// The transmission power level for the device
     pub tx_power_level: Option<i16>,
     /// The most recent Received Signal Strength Indicator for the device

--- a/src/bluez/peripheral.rs
+++ b/src/bluez/peripheral.rs
@@ -144,6 +144,7 @@ impl api::Peripheral for Peripheral {
             address: device_info.mac_address.into(),
             address_type: Some(device_info.address_type.into()),
             local_name: device_info.name,
+            advertisement_name: None,
             tx_power_level: device_info.tx_power,
             rssi: device_info.rssi,
             manufacturer_data: device_info.manufacturer_data,

--- a/src/corebluetooth/adapter.rs
+++ b/src/corebluetooth/adapter.rs
@@ -57,22 +57,28 @@ impl Adapter {
                 match msg {
                     CoreBluetoothEvent::DeviceDiscovered {
                         uuid,
-                        name,
+                        local_name,
+                        advertisement_name,
                         event_receiver,
                     } => {
                         manager_clone.add_peripheral(Peripheral::new(
                             uuid,
-                            name,
+                            local_name,
+                            advertisement_name,
                             Arc::downgrade(&manager_clone),
                             event_receiver,
                             adapter_sender_clone.clone(),
                         ));
                         manager_clone.emit(CentralEvent::DeviceDiscovered(uuid.into()));
                     }
-                    CoreBluetoothEvent::DeviceUpdated { uuid, name } => {
+                    CoreBluetoothEvent::DeviceUpdated {
+                        uuid,
+                        local_name,
+                        advertisement_name,
+                    } => {
                         let id = uuid.into();
                         if let Some(entry) = manager_clone.peripheral_mut(&id) {
-                            entry.value().update_name(&name);
+                            entry.value().update_name(local_name, advertisement_name);
                             manager_clone.emit(CentralEvent::DeviceUpdated(id));
                         }
                     }

--- a/src/corebluetooth/central_delegate.rs
+++ b/src/corebluetooth/central_delegate.rs
@@ -46,7 +46,7 @@ pub enum CentralDelegateEvent {
     },
     DiscoveredPeripheral {
         cbperipheral: Retained<CBPeripheral>,
-        local_name: Option<String>,
+        advertisement_name: Option<String>,
     },
     DiscoveredServices {
         peripheral_uuid: Uuid,
@@ -136,11 +136,11 @@ impl Debug for CentralDelegateEvent {
                 .finish(),
             CentralDelegateEvent::DiscoveredPeripheral {
                 cbperipheral,
-                local_name,
+                advertisement_name,
             } => f
                 .debug_struct("CentralDelegateEvent")
                 .field("cbperipheral", cbperipheral.deref())
-                .field("local_name", local_name)
+                .field("advertisement_name", advertisement_name)
                 .finish(),
             CentralDelegateEvent::DiscoveredServices {
                 peripheral_uuid,
@@ -385,14 +385,14 @@ declare_class!(
                 peripheral_debug(peripheral)
             );
 
-            let local_name = adv_data
+            let advertisement_name = adv_data
                 .get(unsafe { CBAdvertisementDataLocalNameKey })
                 .map(|name| (name as *const AnyObject as *const NSString))
                 .and_then(|name| unsafe { nsstring_to_string(name) });
 
             self.send_event(CentralDelegateEvent::DiscoveredPeripheral {
                 cbperipheral: peripheral.retain(),
-                local_name,
+                advertisement_name,
             });
 
             let rssi_value = rssi.as_i16();

--- a/src/corebluetooth/internal.rs
+++ b/src/corebluetooth/internal.rs
@@ -461,12 +461,14 @@ pub enum CoreBluetoothEvent {
     },
     DeviceDiscovered {
         uuid: Uuid,
-        name: Option<String>,
+        local_name: Option<String>,
+        advertisement_name: Option<String>,
         event_receiver: Receiver<PeripheralEventInternal>,
     },
     DeviceUpdated {
         uuid: Uuid,
-        name: String,
+        local_name: Option<String>,
+        advertisement_name: Option<String>,
     },
     DeviceDisconnected {
         uuid: Uuid,
@@ -569,26 +571,20 @@ impl CoreBluetoothInternal {
     async fn on_discovered_peripheral(
         &mut self,
         peripheral: Retained<CBPeripheral>,
-        local_name: Option<String>,
+        advertisement_name: Option<String>,
     ) {
         let uuid = nsuuid_to_uuid(unsafe { &peripheral.identifier() });
         let peripheral_name = unsafe { peripheral.name() };
-
-        let name = match (peripheral_name.map(|n| n.to_string()), local_name) {
-            (Some(p_name), Some(l_name)) if p_name != l_name => {
-                Some(format!("{p_name} [{l_name}]"))
-            }
-            (Some(p_name), Some(_)) => Some(p_name),
-            (Some(p_name), None) => Some(p_name),
-            (None, Some(l_name)) => Some(l_name),
-            (None, None) => None,
-        };
+        let local_name = peripheral_name
+            .map(|n| n.to_string())
+            .or(advertisement_name.clone());
 
         if self.peripherals.contains_key(&uuid) {
-            if let Some(name) = name {
+            if local_name.is_some() {
                 self.dispatch_event(CoreBluetoothEvent::DeviceUpdated {
                     uuid,
-                    name: name.to_string(),
+                    local_name,
+                    advertisement_name,
                 })
                 .await;
             }
@@ -599,7 +595,8 @@ impl CoreBluetoothInternal {
                 .insert(uuid, PeripheralInternal::new(peripheral, event_sender));
             self.dispatch_event(CoreBluetoothEvent::DeviceDiscovered {
                 uuid,
-                name: name.map(|name| name.to_string()),
+                local_name,
+                advertisement_name,
                 event_receiver,
             })
             .await;
@@ -1095,8 +1092,8 @@ impl CoreBluetoothInternal {
                     CentralDelegateEvent::DidUpdateState{state} => {
                         self.dispatch_event(CoreBluetoothEvent::DidUpdateState{state}).await
                     }
-                    CentralDelegateEvent::DiscoveredPeripheral{cbperipheral, local_name} => {
-                        self.on_discovered_peripheral(cbperipheral, local_name).await
+                    CentralDelegateEvent::DiscoveredPeripheral{cbperipheral, advertisement_name} => {
+                        self.on_discovered_peripheral(cbperipheral, advertisement_name).await
                     }
                     CentralDelegateEvent::DiscoveredServices{peripheral_uuid, services} => {
                         self.on_discovered_services(peripheral_uuid, services)

--- a/src/corebluetooth/peripheral.rs
+++ b/src/corebluetooth/peripheral.rs
@@ -94,6 +94,7 @@ impl Peripheral {
             address: BDAddr::default(),
             address_type: None,
             local_name,
+            advertisement_name: None,
             tx_power_level: None,
             rssi: None,
             manufacturer_data: HashMap::new(),

--- a/src/corebluetooth/peripheral.rs
+++ b/src/corebluetooth/peripheral.rs
@@ -84,6 +84,7 @@ impl Peripheral {
     pub(crate) fn new(
         uuid: Uuid,
         local_name: Option<String>,
+        advertisement_name: Option<String>,
         manager: Weak<AdapterManager<Self>>,
         event_receiver: Receiver<PeripheralEventInternal>,
         message_sender: Sender<CoreBluetoothMessage>,
@@ -94,7 +95,7 @@ impl Peripheral {
             address: BDAddr::default(),
             address_type: None,
             local_name,
-            advertisement_name: None,
+            advertisement_name,
             tx_power_level: None,
             rssi: None,
             manufacturer_data: HashMap::new(),
@@ -172,8 +173,15 @@ impl Peripheral {
         Self { shared: shared }
     }
 
-    pub(super) fn update_name(&self, name: &str) {
-        self.shared.properties.lock().unwrap().local_name = Some(name.to_string());
+    pub(super) fn update_name(
+        &self,
+        local_name: Option<String>,
+        advertisement_name: Option<String>,
+    ) {
+        if let Ok(mut props) = self.shared.properties.lock() {
+            props.local_name = local_name;
+            props.advertisement_name = advertisement_name;
+        }
     }
 }
 

--- a/src/droidplug/jni/objects.rs
+++ b/src/droidplug/jni/objects.rs
@@ -733,6 +733,7 @@ impl<'a: 'b, 'b> TryFrom<JScanResult<'a, 'b>> for (BDAddr, Option<PeripheralProp
                 address: addr,
                 address_type: None,
                 local_name: device_name,
+                advertisement_name: None,
                 tx_power_level,
                 manufacturer_data,
                 service_data,

--- a/src/winrtble/peripheral.rs
+++ b/src/winrtble/peripheral.rs
@@ -117,6 +117,7 @@ impl Peripheral {
             address: self.address(),
             address_type: *self.shared.address_type.read().unwrap(),
             local_name: self.shared.local_name.read().unwrap().clone(),
+            advertisement_name: None,
             tx_power_level: *self.shared.last_tx_power_level.read().unwrap(),
             rssi: *self.shared.last_rssi.read().unwrap(),
             manufacturer_data: self.shared.latest_manufacturer_data.read().unwrap().clone(),


### PR DESCRIPTION
as [well described here](https://github.com/deviceplug/btleplug/issues/434) peripheral `local_name` and `advertisement_name`  are two different things and it is justified to keep them separated as situation that local_name is not equal advertisement_name could happen in all platforms and can be implemented later as followup.

currently it is quite unfortunate that the API changes the peripheral local_name (GAP) by joining those two values

changes:
1. added `Peripheral.advertisement_name` - default None
2. implement advertisement_name in corebluetooth


fix: https://github.com/deviceplug/btleplug/issues/434