### PR TITLE
feat: add Adapter `retrieve_peripherals` method

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -209,6 +209,15 @@ pub struct ScanFilter {
     pub services: Vec<Uuid>,
 }
 
+/// Parameters of retrieve_peripherals method.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RetrievePeripheralsOptions {
+    /// retrieve connected peripherals by services
+    services: Option<Vec<Uuid>>,
+    /// retrieve known peripherals by identifiers
+    identifiers: Option<Vec<PeripheralId>>,
+}
+
 /// The type of write operation to use.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum WriteType {
@@ -362,6 +371,12 @@ pub trait Central: Send + Sync + Clone {
     /// Returns the list of [`Peripheral`]s that have been discovered so far. Note that this list
     /// may contain peripherals that are no longer available.
     async fn peripherals(&self) -> Result<Vec<Self::Peripheral>>;
+
+    /// Returns the list of known or connected [`Peripheral`]s
+    async fn retrieve_peripherals(
+        &self,
+        options: RetrievePeripheralsOptions,
+    ) -> Result<Vec<Self::Peripheral>>;
 
     /// Returns a particular [`Peripheral`] by its address if it has been discovered.
     async fn peripheral(&self, id: &PeripheralId) -> Result<Self::Peripheral>;

--- a/src/bluez/adapter.rs
+++ b/src/bluez/adapter.rs
@@ -1,5 +1,5 @@
 use super::peripheral::{Peripheral, PeripheralId};
-use crate::api::{Central, CentralEvent, CentralState, ScanFilter};
+use crate::api::{Central, CentralEvent, CentralState, RetrievePeripheralsOptions, ScanFilter};
 use crate::{Error, Result};
 use async_trait::async_trait;
 use bluez_async::{
@@ -89,6 +89,13 @@ impl Central for Adapter {
             .into_iter()
             .map(|device| Peripheral::new(self.session.clone(), device))
             .collect())
+    }
+
+    async fn retrieve_peripherals(
+        &self,
+        options: RetrievePeripheralsOptions,
+    ) -> Result<Vec<Peripheral>> {
+        Err(Error::NotSupported("Not implemented".to_string()))
     }
 
     async fn peripheral(&self, id: &PeripheralId) -> Result<Peripheral> {

--- a/src/corebluetooth/adapter.rs
+++ b/src/corebluetooth/adapter.rs
@@ -3,7 +3,7 @@ use super::internal::{
     CoreBluetoothReplyFuture,
 };
 use super::peripheral::{Peripheral, PeripheralId};
-use crate::api::{Central, CentralEvent, CentralState, ScanFilter};
+use crate::api::{Central, CentralEvent, CentralState, RetrievePeripheralsOptions, ScanFilter};
 use crate::common::adapter_manager::AdapterManager;
 use crate::{Error, Result};
 use async_trait::async_trait;
@@ -120,6 +120,13 @@ impl Central for Adapter {
 
     async fn peripherals(&self) -> Result<Vec<Peripheral>> {
         Ok(self.manager.peripherals())
+    }
+
+    async fn retrieve_peripherals(
+        &self,
+        options: RetrievePeripheralsOptions,
+    ) -> Result<Vec<Peripheral>> {
+        Err(Error::NotSupported("Not implemented".to_string()))
     }
 
     async fn peripheral(&self, id: &PeripheralId) -> Result<Peripheral> {

--- a/src/droidplug/adapter.rs
+++ b/src/droidplug/adapter.rs
@@ -6,7 +6,10 @@ use super::{
     peripheral::{Peripheral, PeripheralId},
 };
 use crate::{
-    api::{BDAddr, Central, CentralEvent, CentralState, PeripheralProperties, ScanFilter},
+    api::{
+        BDAddr, Central, CentralEvent, CentralState, PeripheralProperties,
+        RetrievePeripheralsOptions, ScanFilter,
+    },
     common::adapter_manager::AdapterManager,
     Error, Result,
 };
@@ -156,6 +159,13 @@ impl Central for Adapter {
 
     async fn peripherals(&self) -> Result<Vec<Peripheral>> {
         Ok(self.manager.peripherals())
+    }
+
+    async fn retrieve_peripherals(
+        &self,
+        options: RetrievePeripheralsOptions,
+    ) -> Result<Vec<Peripheral>> {
+        Err(Error::NotSupported("Not implemented".to_string()))
     }
 
     async fn peripheral(&self, address: &PeripheralId) -> Result<Peripheral> {

--- a/src/winrtble/adapter.rs
+++ b/src/winrtble/adapter.rs
@@ -13,7 +13,7 @@
 
 use super::{ble::watcher::BLEWatcher, peripheral::Peripheral, peripheral::PeripheralId};
 use crate::{
-    api::{BDAddr, Central, CentralEvent, CentralState, ScanFilter},
+    api::{BDAddr, Central, CentralEvent, CentralState, RetrievePeripheralsOptions, ScanFilter},
     common::adapter_manager::AdapterManager,
     Error, Result,
 };
@@ -116,6 +116,13 @@ impl Central for Adapter {
 
     async fn peripherals(&self) -> Result<Vec<Peripheral>> {
         Ok(self.manager.peripherals())
+    }
+
+    async fn retrieve_peripherals(
+        &self,
+        options: RetrievePeripheralsOptions,
+    ) -> Result<Vec<Peripheral>> {
+        Err(Error::NotSupported("Not implemented".to_string()))
     }
 
     async fn peripheral(&self, id: &PeripheralId) -> Result<Peripheral> {


### PR DESCRIPTION
This is empty prerequisite for:
- retrieve connected peripherals (by services uuid) https://github.com/deviceplug/btleplug/pull/437
- retrieve known peripherals (by device identifiers) - i will add the implementation for corebluetooth, windows and linux in following pull requests.

List of platforms where the method could be implemented

|          | paired/connected visible | retrieve by identifier | retrieve by services |
|----------|--------------------------|------------------------|----------------------|
| macOS    | NO                       | YES                    | YES                  |
| Linux    | YES                      | YES (default)          | YES (default)        |
| Windows  | NO                       | YES                    | YES                  |
| Android  | ?                        | ?                      | ?                    |

im not familiar with `droidplug` but im sure it is also possible to implement if needed.