### PR TITLE
Android: Initialize jni-utils

### DIFF
--- a/src/droidplug/jni/mod.rs
+++ b/src/droidplug/jni/mod.rs
@@ -9,6 +9,8 @@ static GLOBAL_JVM: OnceCell<JavaVM> = OnceCell::new();
 
 pub fn init(env: &JNIEnv) -> crate::Result<()> {
     if let Ok(()) = GLOBAL_JVM.set(env.get_java_vm()?) {
+        jni_utils::init(&env).unwrap();
+
         env.register_native_methods(
             "com/nonpolynomial/btleplug/android/impl/Adapter",
             &[


### PR DESCRIPTION
I'm in the process of integrating this library into an Android application and am hoping to contribute a handful of improvements to help address some of the challenges folks face when getting this to work.

This first change is to push initialization of the `jni-utils-rs` crate into this library directly. This is a critical step to getting callbacks from the Java code to wake up Rust futures, but is not consistently shown in the examples I've tracked down. Some examples establish peer dependencies on `btleplug` and `jni-utils-rs`, but those need to be carefully version-matched, causing fragility (and unfortunately in my testing, silent bugs that are hard to run down).

Since `btleplug` directly depends on this crate, the initialization here made sense. I don't love the `unwrap()` and am very open to ideas about how to better surface these types of early initialization errors to the application.