### PR TITLE
Fix clear_peripherals on CoreBluetooth to clear internal map

### DIFF
--- a/src/corebluetooth/adapter.rs
+++ b/src/corebluetooth/adapter.rs
@@ -140,6 +140,11 @@ impl Central for Adapter {
 
     async fn clear_peripherals(&self) -> Result<()> {
         self.manager.clear_peripherals();
+        self.sender
+            .to_owned()
+            .send(CoreBluetoothMessage::ClearPeripherals)
+            .await
+            .map_err(|e| Error::Other(Box::new(e)))?;
         Ok(())
     }
 

--- a/src/corebluetooth/internal.rs
+++ b/src/corebluetooth/internal.rs
@@ -499,6 +499,7 @@ pub enum CoreBluetoothMessage {
         peripheral_uuid: Uuid,
         future: CoreBluetoothReplyStateShared,
     },
+    ClearPeripherals,
 }
 
 #[derive(Debug)]
@@ -1437,6 +1438,9 @@ impl CoreBluetoothInternal {
                     }
                     CoreBluetoothMessage::ReadRssi{peripheral_uuid, future} => {
                         self.read_rssi(peripheral_uuid, future)
+                    }
+                    CoreBluetoothMessage::ClearPeripherals => {
+                        self.peripherals.clear();
                     }
                 };
             }


### PR DESCRIPTION
## Summary

`clear_peripherals()` only clears the `AdapterManager`'s public `DashMap` but not `CoreBluetoothInternal`'s private `HashMap`. After clearing, re-discovered peripherals are treated as `DeviceUpdated` (already known internally) instead of `DeviceDiscovered`, so they are never re-added to the public map.

This adds a `ClearPeripherals` message to the CoreBluetooth thread so both maps are cleared in sync.

## Context

I discovered this while adding `clear_peripherals()` to the scan loop in [tauri-plugin-blec](https://github.com/MnlPhlp/tauri-plugin-blec) to prevent stale/duplicate devices accumulating across scan restarts. On macOS, devices disappeared after clearing and never came back. With a bit of help from Claude, I eventually worked out it's because the internal map is not being cleared, causing `DeviceUpdated` instead of `DeviceDiscovered` on re-discovery.

## Details

Following the existing message-passing pattern used by `StartScanning`, `StopScanning`, etc:

1. Add `ClearPeripherals` variant to `CoreBluetoothMessage`
2. Handle it in the message loop by clearing `self.peripherals`
3. Send the message from `Adapter::clear_peripherals()` after clearing the `AdapterManager` map

## Testing

Tested in a Tauri BLE application on macOS. Called `clear_peripherals()` between scan restarts. Before this fix, devices vanished permanently after clearing. After this fix, devices are correctly re-discovered and returned by `peripherals()`.