### PR TITLE
winrtble: also receive on the Coded PHY where supported

### DIFF
--- a/src/winrtble/ble/watcher.rs
+++ b/src/winrtble/ble/watcher.rs
@@ -77,6 +77,11 @@ impl BLEWatcher {
         self.watcher
             .SetScanningMode(BluetoothLEScanningMode::Active)?;
         let _ = self.watcher.SetAllowExtendedAdvertisements(true);
+        // Also receive on the Coded (long-range) PHY where the adapter and
+        // OS support it. Only takes effect alongside extended advertisements
+        // (above); the error is ignored the same way, so systems without
+        // Coded PHY support behave exactly as before.
+        let _ = self.watcher.SetUseCodedPhy(true);
 
         // Pre-convert the filter UUIDs once so the handler closure is cheap.
         let filter_guids: Vec<windows::core::GUID> = services.iter().map(utils::to_guid).collect();


### PR DESCRIPTION
## What

One line in `BLEWatcher::start`: enable `UseCodedPhy(true)` on the
`BluetoothLEAdvertisementWatcher`, next to the existing unconditional
`SetAllowExtendedAdvertisements(true)` and with the same error-ignored
pattern.

## Why

Without it, the Windows backend never receives BLE 5 **coded-primary
(long range) advertisements**, even on adapters that support them.
Extended advertisements are announced on the primary channels using
either the 1M or the Coded PHY (2M is secondary-channel-only, and the
controller follows AUX pointers to any secondary PHY automatically);
`AllowExtendedAdvertisements` alone leaves the scanner listening on 1M
primaries only. `UseCodedPhy` is documented to take effect only
alongside `AllowExtendedAdvertisements`, which this watcher already
sets, so this completes the pair.

The call fails harmlessly on systems without Coded PHY support (older
Windows builds / non-coded adapters); the error is ignored exactly like
the extended flag above it, so behavior there is unchanged. On supported
systems, 1M reception is unaffected — coded scanning is additive.