### PR TITLE
feat(winrtble): implement add_peripheral (connect by address)

### DIFF
--- a/src/winrtble/adapter.rs
+++ b/src/winrtble/adapter.rs
@@ -122,10 +122,15 @@ impl Central for Adapter {
         self.manager.peripheral(id).ok_or(Error::DeviceNotFound)
     }
 
-    async fn add_peripheral(&self, _address: &PeripheralId) -> Result<Peripheral> {
-        Err(Error::NotSupported(
-            "Can't add a Peripheral from a BDAddr".to_string(),
-        ))
+    async fn add_peripheral(&self, id: &PeripheralId) -> Result<Peripheral> {
+        if let Some(peripheral) = self.manager.peripheral(id) {
+            return Ok(peripheral);
+        }
+        // Create a peripheral straight from its address so a device the OS already knows (bonded or
+        // connected to another central) can be reached without waiting for an advertisement.
+        let peripheral = Peripheral::new(Arc::downgrade(&self.manager), id.clone().into());
+        self.manager.add_peripheral(peripheral.clone());
+        Ok(peripheral)
     }
 
     async fn clear_peripherals(&self) -> Result<()> {

--- a/src/winrtble/peripheral.rs
+++ b/src/winrtble/peripheral.rs
@@ -671,3 +671,9 @@ impl From<BDAddr> for PeripheralId {
         PeripheralId(address)
     }
 }
+
+impl From<PeripheralId> for BDAddr {
+    fn from(id: PeripheralId) -> Self {
+        id.0
+    }
+}


### PR DESCRIPTION
## What

Implement the WinRT Central::add_peripheral, which currently returns Err(NotSupported). It creates a Peripheral from the given PeripheralId the same way the scanner registers a discovered device, and returns an already-known entry if present. Also adds the symmetric From<PeripheralId> for BDAddr.

## Why

add_peripheral was added to the Central trait in 0.12.0 for Android but left unimplemented on Windows. Without it, a device the OS already knows (bonded, or connected to another central such as a phone) cannot be reached on Windows unless it happens to be advertising. This brings WinRT to parity with Android: get a Peripheral by address, then call connect(), which already uses FromBluetoothAddressAsync.

Tested on hardware: connects to a bonded device that is connected to another central and is not advertising, then reads and writes its GATT.
