### PR TITLE
Raise droidplug's minSdk to 24 to match the API it uses

### DIFF
--- a/src/droidplug/java/build.gradle
+++ b/src/droidplug/java/build.gradle
@@ -12,7 +12,7 @@ android {
     compileSdk 34
 
     defaultConfig {
-        minSdk 23
+        minSdk 24
         versionCode 1
         versionName '0.7.3'
     }


### PR DESCRIPTION
The interfaces `FnFunction` and `FnBiFunction` extend `java.util.function.Function` and `java.util.function.BiFunction`, both introduced in API 24, while the library declared `minSdk 23`. Lint flags both as errors, so `./gradlew build` fails on a clean checkout; the declared floor also misrepresents what the library can actually run on. `FnBiFunctionImpl` is registered in the class cache by `platform::init`, so on an API 23 device without core library desugaring resolving it can fail at runtime rather than at build time.

This change bumps the API level to match actual API used.